### PR TITLE
Fix clock progression when rolling success

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -43,7 +43,8 @@ struct ContentView: View {
                 Button("Roll") {
                     if let action = pendingAction,
                        let character = viewModel.gameState.party.first {
-                        viewModel.performAction(for: action, with: character, onClock: nil)
+                        let clockID = viewModel.gameState.activeClocks.first?.id
+                        viewModel.performAction(for: action, with: character, onClock: clockID)
                     }
                 }
                 Button("Cancel", role: .cancel) { }


### PR DESCRIPTION
## Summary
- wire up `performAction` with active clock ID

## Testing
- `xcodebuild -version` *(fails: command not found)*