### PR TITLE
Implement dungeon generation in GameViewModel

### DIFF
--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -3,6 +3,8 @@ import Foundation
 struct GameState: Codable {
     var party: [Character] = []
     var activeClocks: [GameClock] = []
+    var dungeon: DungeonMap? // The full map
+    var currentNodeID: UUID? // The party's current location
     // ... other global state can be added later
 }
 


### PR DESCRIPTION
## Summary
- store the dungeon map in `GameState`
- generate a basic three-node dungeon in `GameViewModel`
- provide a helper for the current node
- add movement between nodes

## Testing
- `swift test` *(fails: Could not find Package.swift)*