### PR TITLE
Implement dungeon node views

### DIFF
--- a/CardGame/NodeConnectionsView.swift
+++ b/CardGame/NodeConnectionsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct NodeConnectionsView: View {
+    var currentNode: MapNode?
+    let onMove: (NodeConnection) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Paths from this room")
+                .font(.headline)
+            if let node = currentNode {
+                ForEach(node.connections, id: \.toNodeID) { connection in
+                    Button {
+                        onMove(connection)
+                    } label: {
+                        HStack {
+                            Text(connection.description)
+                            Spacer()
+                            if !connection.isUnlocked {
+                                Image(systemName: "lock.fill")
+                            }
+                            Image(systemName: "arrow.right.circle.fill")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!connection.isUnlocked)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a NodeConnectionsView for moving between nodes
- show the current node interactables and connections in ContentView

## Testing
- `swift test` *(fails: Could not find Package.swift)*