### PR TITLE
Fix overlapping UI elements

### DIFF
--- a/CardGame/ClocksView.swift
+++ b/CardGame/ClocksView.swift
@@ -13,6 +13,7 @@ struct ClocksView: View {
                         GraphicalClockView(clock: clock)
                     }
                 }
+                .padding(.bottom, 8)
             }
         }
     }

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -48,6 +48,7 @@ struct ContentView: View {
                 }
                 .padding()
                 .navigationTitle(viewModel.currentNode?.name ?? "Unknown Location")
+                .navigationBarTitleDisplayMode(.inline)
                 .sheet(item: $pendingAction) { action in
                     if let character = selectedCharacter {
                         let clockID = viewModel.gameState.activeClocks.first?.id


### PR DESCRIPTION
## Summary
- keep the room title from overlapping the CharacterSelector
- add a little bottom padding in `ClocksView` so the clock graphic is fully visible

## Testing
- `git log -1 --stat`