### PR TITLE
Fix overlapping UI elements

### DIFF
--- a/CardGame/ClocksView.swift
+++ b/CardGame/ClocksView.swift
@@ -13,6 +13,7 @@ struct ClocksView: View {
                         GraphicalClockView(clock: clock)
                     }
                 }
+                .padding(.bottom, 8)
             }
         }
     }

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -47,7 +47,6 @@ struct ContentView: View {
                     }
                 }
                 .padding()
-                .navigationTitle(viewModel.currentNode?.name ?? "Unknown Location")
                 .sheet(item: $pendingAction) { action in
                     if let character = selectedCharacter {
                         let clockID = viewModel.gameState.activeClocks.first?.id
@@ -60,6 +59,10 @@ struct ContentView: View {
                     }
                 }
             }
+            .navigationTitle(viewModel.currentNode?.name ?? "Unknown Location")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(.stack)
+
 
             if viewModel.gameState.status == .gameOver {
                 Color.black.opacity(0.75).ignoresSafeArea()


### PR DESCRIPTION
## Summary
- keep the clock list from being clipped
- stabilize navigation bar layout so the CharacterSelector doesn't overlap the title

## Testing
- `swift test` *(fails: no Package.swift)*