### PR TITLE
Fix SlidingDoor image fill

### DIFF
--- a/CardGame/AssetPlaceholders/texture_stone_door.md
+++ b/CardGame/AssetPlaceholders/texture_stone_door.md
@@ -1,0 +1,2 @@
+# Placeholder Image: texture_stone_door.png
+A 256x256 repeating stone texture used for the sliding door transition.

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -142,8 +142,7 @@ struct SlidingDoor: View {
             HStack(spacing: 0) {
                 Rectangle()
                     .fill(
-                        Image("texture_stone_door")
-                            .resizable(resizingMode: .tile)
+                        ImagePaint(image: Image("texture_stone_door"), scale: 1)
                     )
                     .frame(width: geo.size.width * progress)
                 Spacer(minLength: 0)


### PR DESCRIPTION
## Summary
- patch `SlidingDoor` to use `ImagePaint`
- add placeholder for `texture_stone_door.png`

## Testing
- `swift --version`