### PR TITLE
Expand placeholder content and update loaders

### DIFF
--- a/CardGame/ContentLoader.swift
+++ b/CardGame/ContentLoader.swift
@@ -21,7 +21,14 @@ class ContentLoader {
         do {
             let data = try Data(contentsOf: url)
             let decoder = JSONDecoder()
-            return try decoder.decode([T].self, from: data)
+            if let array = try? decoder.decode([T].self, from: data) {
+                return array
+            } else if let dict = try? decoder.decode([String: [T]].self, from: data) {
+                return dict.flatMap { $0.value }
+            } else {
+                print("Failed to decode \(filename): unexpected format")
+                return []
+            }
         } catch {
             print("Failed to decode \(filename): \(error)")
             return []

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var viewModel: GameViewModel
     @State private var pendingAction: ActionOption?
+    @State private var pendingInteractableID: UUID?
     @State private var selectedCharacterID: UUID? // Track selected character
     @State private var showingStatusSheet = false // Controls the party sheet
     @State private var doorProgress: CGFloat = 0 // For sliding door transition
@@ -50,6 +51,7 @@ struct ContentView: View {
                                     InteractableCardView(interactable: interactable) { action in
                                         if selectedCharacter != nil {
                                             pendingAction = action
+                                            pendingInteractableID = interactable.id
                                         }
                                     }
                                     .transition(.scale(scale: 0.9).combined(with: .opacity))
@@ -78,7 +80,8 @@ struct ContentView: View {
                     DiceRollView(viewModel: viewModel,
                                  action: action,
                                  character: character,
-                                 clockID: clockID)
+                                 clockID: clockID,
+                                 interactableID: pendingInteractableID)
                 } else {
                     Text("No action selected")
                 }

--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -11,6 +11,7 @@ struct DiceRollView: View {
     let action: ActionOption
     let character: Character
     let clockID: UUID?
+    let interactableID: UUID?
 
     @State private var diceValues: [Int] = []
     @State private var diceOffsets: [CGSize] = []
@@ -54,7 +55,7 @@ struct DiceRollView: View {
         showVignette = false
         isRolling = false
         AudioManager.shared.play(sound: "sfx_dice_land.wav")
-        let rollResult = viewModel.performAction(for: action, with: character)
+        let rollResult = viewModel.performAction(for: action, with: character, interactableID: interactableID)
         self.result = rollResult
         let totalDice = diceValues.count
         highlightIndex = Int.random(in: 0..<totalDice)

--- a/Content/harm_families.json
+++ b/Content/harm_families.json
@@ -20,6 +20,20 @@
       "moderate": { "description": "Seared Nerves", "penalty": { "type": "reduceEffect" } },
       "severe": { "description": "Nerve Damage", "penalty": { "type": "banAction", "actionType": "Tinker" } },
       "fatal": { "description": "Heart Stops" }
+    },
+    {
+      "id": "mental_anguish",
+      "lesser": { "description": "Unease", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "moderate": { "description": "Fleeting Shadows", "penalty": { "type": "actionPenalty", "actionType": "Survey" } },
+      "severe": { "description": "Terror", "penalty": { "type": "reduceEffect" } },
+      "fatal": { "description": "Mind Broken" }
+    },
+    {
+      "id": "gear_damage",
+      "lesser": { "description": "Frayed Rope", "penalty": { "type": "actionPenalty", "actionType": "Finesse" } },
+      "moderate": { "description": "Broken Tools", "penalty": { "type": "banAction", "actionType": "Tinker" } },
+      "severe": { "description": "Lost Map", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "fatal": { "description": "Stranded and Helpless" }
     }
   ]
 }

--- a/Content/interactables.json
+++ b/Content/interactables.json
@@ -43,5 +43,151 @@
         }
       ]
     }
+    ,
+    {
+      "id": "template_crumbling_ledge",
+      "title": "Crumbling Ledge",
+      "description": "A narrow ledge over a dark chasm. It looks unstable.",
+      "availableActions": [
+        {
+          "name": "Cross Carefully",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [
+              { "type": "gainStress", "amount": 2 },
+              { "type": "sufferHarm", "level": "lesser", "familyId": "leg_injury" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" },
+              { "type": "tickClock", "clockName": "Chasm Peril", "amount": 2 }
+            ]
+          }
+        },
+        {
+          "name": "Test its Stability",
+          "actionType": "Survey",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_mysterious_whispers",
+      "title": "Mysterious Whispers",
+      "description": "Voices echo softly from unseen sources.",
+      "availableActions": [
+        {
+          "name": "Listen Closely",
+          "actionType": "Attune",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_map_fragment" } ],
+            "partial": [ { "type": "sufferHarm", "level": "lesser", "familyId": "mental_anguish" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "mental_anguish" } ]
+          }
+        },
+        {
+          "name": "Block Out Noise",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_jammed_lock",
+      "title": "Jammed Lock",
+      "description": "A sturdy door with a rusted mechanism.",
+      "availableActions": [
+        {
+          "name": "Pick the Lock",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_precise_tools" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Lockdown Approaches", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "gear_damage" } ]
+          }
+        },
+        {
+          "name": "Force it",
+          "actionType": "Wreck",
+          "position": "desperate",
+          "effect": "great",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_unstable_rune",
+      "title": "Unstable Rune",
+      "description": "A glowing rune pulsates with dangerous energy.",
+      "availableActions": [
+        {
+          "name": "Decode Glyphs",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Rune Overload", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Shatter it",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_hidden_niche",
+      "title": "Hidden Niche",
+      "description": "A faint outline hints at a recess in the wall.",
+      "availableActions": [
+        {
+          "name": "Search Carefully",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Finesse", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "tickClock", "clockName": "Chest Trap", "amount": 1 } ] } } ] } } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        },
+        {
+          "name": "Force it Open",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Wreck", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ] } } ] } } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    }
   ]
 }

--- a/Content/treasures.json
+++ b/Content/treasures.json
@@ -16,5 +16,47 @@
       "improveEffect": true,
       "description": "Lucky Find"
     }
+  },
+  {
+    "id": "treasure_steadying_herbs",
+    "name": "Steadying Herbs",
+    "description": "Chewing these calms the nerves, for a time.",
+    "grantedModifier": {
+      "improvePosition": true,
+      "uses": 1,
+      "description": "from Steadying Herbs"
+    }
+  },
+  {
+    "id": "treasure_precise_tools",
+    "name": "Set of Precise Tools",
+    "description": "Ideal instruments for delicate work.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Tinker",
+      "uses": 2,
+      "description": "from Precise Tools"
+    }
+  },
+  {
+    "id": "treasure_charmed_talisman",
+    "name": "Charmed Talisman",
+    "description": "Offers fleeting protection from dark thoughts.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Attune",
+      "uses": 1,
+      "description": "from Charmed Talisman"
+    }
+  },
+  {
+    "id": "treasure_map_fragment",
+    "name": "Map Fragment",
+    "description": "Hints at a secret room somewhere in the tomb.",
+    "grantedModifier": {
+      "improveEffect": true,
+      "uses": 1,
+      "description": "from Map Fragment"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- add variety to harm families, treasures, and interactables
- support dictionary-style JSON in `ContentLoader`
- allow special consequence cases (self-removal, add to current node, treasure IDs)
- plumb interactable context through the UI

## Testing
- `swift test` *(fails: Could not find Package.swift)*