### PR TITLE
Display skill info in DiceRollView

### DIFF
--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -88,6 +88,9 @@ struct DiceRollView: View {
             Text(character.name).font(.title)
             Text("is attempting to...").font(.subheadline).foregroundColor(.secondary)
             Text(action.name).font(.title2).bold()
+            Text("\(action.actionType): \(character.actions[action.actionType] ?? 0)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
 
             Spacer()
 


### PR DESCRIPTION
## Summary
- show the action's skill and its rating beneath the action name in DiceRollView

## Testing
- `xcodebuild test -project CardGame.xcodeproj -scheme CardGame -destination 'platform=iOS Simulator,name=iPhone 8'` *(fails: command not found)*