### PR TITLE
Add character sheet view

### DIFF
--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct CharacterSheetView: View {
+    let character: Character
+    var locationName: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(character.name)
+                .font(.subheadline)
+                .bold()
+
+            if let locationName {
+                Text("At: \(locationName)")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            }
+
+            // Stress indicator
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Stress \(character.stress)/9")
+                    .font(.caption2)
+                HStack(spacing: 2) {
+                    ForEach(1...9, id: \.self) { index in
+                        Image(character.stress >= index ? "icon_stress_pip_lit" : "icon_stress_pip_unlit")
+                            .resizable()
+                            .frame(width: 12, height: 12)
+                    }
+                }
+            }
+
+            // Harm indicator
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Harm")
+                    .font(.caption2)
+                HStack {
+                    ForEach(0..<HarmState.lesserSlots, id: \.self) { index in
+                        Image(index < character.harm.lesser.count ? "icon_harm_lesser_full" : "icon_harm_lesser_empty")
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                    }
+                    ForEach(0..<HarmState.moderateSlots, id: \.self) { index in
+                        Image(index < character.harm.moderate.count ? "icon_harm_moderate_full" : "icon_harm_moderate_empty")
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                    }
+                    ForEach(0..<HarmState.severeSlots, id: \.self) { index in
+                        Image(index < character.harm.severe.count ? "icon_harm_severe_full" : "icon_harm_severe_empty")
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                    }
+                }
+                ForEach(Array(character.harm.lesser.enumerated()), id: \.offset) { _, entry in
+                    Text("Lesser - \(entry.description)")
+                        .font(.caption2)
+                }
+                ForEach(Array(character.harm.moderate.enumerated()), id: \.offset) { _, entry in
+                    Text("Moderate - \(entry.description)")
+                        .font(.caption2)
+                }
+                ForEach(Array(character.harm.severe.enumerated()), id: \.offset) { _, entry in
+                    Text("Severe - \(entry.description)")
+                        .font(.caption2)
+                }
+            }
+
+            // Action ratings
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Actions")
+                    .font(.caption2)
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 2) {
+                    ForEach(character.actions.sorted(by: { $0.key < $1.key }), id: \.key) { action, rating in
+                        HStack(spacing: 2) {
+                            Text(action)
+                            HStack(spacing: 1) {
+                                ForEach(0..<rating, id: \.self) { _ in
+                                    Image("icon_stress_pip_lit")
+                                        .resizable()
+                                        .frame(width: 8, height: 8)
+                                }
+                            }
+                        }
+                        .font(.caption2)
+                    }
+                }
+            }
+
+            // Treasures
+            if !character.treasures.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Treasures")
+                        .font(.caption2)
+                    ForEach(character.treasures) { treasure in
+                        Text(treasure.name)
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    CharacterSheetView(character: GameViewModel().gameState.party.first!)
+}

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -47,6 +47,11 @@ struct ContentView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
 
+                        if let character = selectedCharacter {
+                            CharacterSheetView(character: character)
+                            Divider()
+                        }
+
                         if let node = viewModel.node(for: selectedCharacterID) {
                             VStack(alignment: .leading, spacing: 16) {
                                 ForEach(node.interactables, id: \.id) { interactable in

--- a/CardGame/PartyStatusView.swift
+++ b/CardGame/PartyStatusView.swift
@@ -9,100 +9,13 @@ struct PartyStatusView: View {
                 .font(.headline)
 
             ForEach(viewModel.gameState.party) { character in
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(character.name)
-                        .font(.subheadline)
-                        .bold()
+                let loc: String? = {
                     if viewModel.partyMovementMode == .solo && viewModel.isPartyActuallySplit() {
-                        if let locName = viewModel.getNodeName(for: character.id) {
-                            Text("At: \(locName)")
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                        }
+                        return viewModel.getNodeName(for: character.id)
                     }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Stress \(character.stress)/9")
-                            .font(.caption2)
-                        HStack(spacing: 2) {
-                            ForEach(1...9, id: \.self) { index in
-                                Image(character.stress >= index ? "icon_stress_pip_lit" : "icon_stress_pip_unlit")
-                                    .resizable()
-                                    .frame(width: 12, height: 12)
-                            }
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Harm")
-                            .font(.caption2)
-                        HStack {
-                            ForEach(0..<HarmState.lesserSlots, id: \.self) { index in
-                                Image(index < character.harm.lesser.count ? "icon_harm_lesser_full" : "icon_harm_lesser_empty")
-                                    .resizable()
-                                    .frame(width: 16, height: 16)
-                            }
-                            ForEach(0..<HarmState.moderateSlots, id: \.self) { index in
-                                Image(index < character.harm.moderate.count ? "icon_harm_moderate_full" : "icon_harm_moderate_empty")
-                                    .resizable()
-                                    .frame(width: 16, height: 16)
-                            }
-                            ForEach(0..<HarmState.severeSlots, id: \.self) { index in
-                                Image(index < character.harm.severe.count ? "icon_harm_severe_full" : "icon_harm_severe_empty")
-                                    .resizable()
-                                    .frame(width: 16, height: 16)
-                            }
-                        }
-                        // Display the names of each suffered Harm for clarity
-                        ForEach(Array(character.harm.lesser.enumerated()), id: \.offset) { _, entry in
-                            Text("Lesser - \(entry.description)")
-                                .font(.caption2)
-                        }
-                        ForEach(Array(character.harm.moderate.enumerated()), id: \.offset) { _, entry in
-                            Text("Moderate - \(entry.description)")
-                                .font(.caption2)
-                        }
-                        ForEach(Array(character.harm.severe.enumerated()), id: \.offset) { _, entry in
-                            Text("Severe - \(entry.description)")
-                                .font(.caption2)
-                        }
-                    }
-
-                    // Action ratings
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Actions")
-                            .font(.caption2)
-                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 2) {
-                            ForEach(character.actions.sorted(by: { $0.key < $1.key }), id: \.key) { action, rating in
-                                HStack(spacing: 2) {
-                                    Text(action)
-                                    HStack(spacing: 1) {
-                                        ForEach(0..<rating, id: \.self) { _ in
-                                            Image("icon_stress_pip_lit")
-                                                .resizable()
-                                                .frame(width: 8, height: 8)
-                                        }
-                                    }
-                                }
-                                .font(.caption2)
-                            }
-                        }
-                    }
-
-                    // Active modifiers
-                    if !character.modifiers.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Modifiers")
-                                .font(.caption2)
-                            ForEach(Array(character.modifiers.enumerated()), id: \.offset) { index, modifier in
-                                Text("\(modifier.description) (\(modifier.uses) use\(modifier.uses == 1 ? "" : "s") left)")
-                                    .font(.caption2)
-                                    .foregroundColor(.purple)
-                            }
-                        }
-                    }
-                }
-                .padding(.vertical, 2)
+                    return nil
+                }()
+                CharacterSheetView(character: character, locationName: loc)
             }
         }
     }


### PR DESCRIPTION
## Summary
- encapsulate stress, harm, actions, and treasures in new `CharacterSheetView`
- reuse the new sheet in `PartyStatusView` for each character
- show the active character's sheet at the top of the main scroll in `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*