### PR TITLE
Implement threat interactables

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -49,7 +49,10 @@ struct ContentView: View {
 
                         if let node = viewModel.node(for: selectedCharacterID) {
                             VStack(alignment: .leading, spacing: 16) {
-                                ForEach(node.interactables, id: \.id) { interactable in
+                                let threats = node.interactables.filter { $0.isThreat }
+                                let items = threats.isEmpty ? node.interactables : threats
+
+                                ForEach(items, id: \.id) { interactable in
                                     InteractableCardView(interactable: interactable, selectedCharacter: selectedCharacter) { action in
                                         if selectedCharacter != nil {
                                             pendingAction = action
@@ -59,10 +62,12 @@ struct ContentView: View {
                                     .transition(.scale(scale: 0.9).combined(with: .opacity))
                                 }
 
-                                Divider()
+                                if threats.isEmpty {
+                                    Divider()
 
-                                NodeConnectionsView(currentNode: viewModel.node(for: selectedCharacterID)) { connection in
-                                    performTransition(to: connection)
+                                    NodeConnectionsView(currentNode: viewModel.node(for: selectedCharacterID)) { connection in
+                                        performTransition(to: connection)
+                                    }
                                 }
                             }
                             .id(node.id)

--- a/CardGame/InteractableCardView.swift
+++ b/CardGame/InteractableCardView.swift
@@ -67,6 +67,17 @@ struct InteractableCardView: View {
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
         .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(interactable.isThreat ? Color.red : Color.clear, lineWidth: 3)
+        )
+        .overlay(alignment: .topLeading) {
+            if interactable.isThreat {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.red)
+                    .padding(4)
+            }
+        }
         .shadow(radius: 4)
     }
 }

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -213,6 +213,43 @@ struct Interactable: Codable, Identifiable {
     var title: String
     var description: String
     var availableActions: [ActionOption]
+    var isThreat: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, description, availableActions, isThreat
+    }
+
+    init(id: String,
+         title: String,
+         description: String,
+         availableActions: [ActionOption],
+         isThreat: Bool = false) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.availableActions = availableActions
+        self.isThreat = isThreat
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decode(String.self, forKey: .description)
+        availableActions = try container.decode([ActionOption].self, forKey: .availableActions)
+        isThreat = try container.decodeIfPresent(Bool.self, forKey: .isThreat) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(description, forKey: .description)
+        try container.encode(availableActions, forKey: .availableActions)
+        if isThreat {
+            try container.encode(isThreat, forKey: .isThreat)
+        }
+    }
 }
 
 struct ActionOption: Codable {

--- a/Content/interactables.json
+++ b/Content/interactables.json
@@ -190,5 +190,63 @@
         }
       ]
     }
+  ],
+  "threats": [
+    {
+      "id": "threat_hungry_ghoul",
+      "title": "Hungry Ghoul",
+      "description": "A ravenous ghoul lurches from the shadows.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Drive it back",
+          "actionType": "Skirmish",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" } ]
+          }
+        },
+        {
+          "name": "Flee",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "tickClock", "clockName": "Ghoul Pursuit", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "threat_reactor_breach",
+      "title": "Reactor Breach",
+      "description": "Alarms blare as a reactor begins to overload.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Stabilize Reactor",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Evacuate",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 2 } ]
+          }
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- allow Interactable to indicate `isThreat`
- highlight threats in `InteractableCardView`
- hide other interactables and navigation when a threat is present
- add sample threat interactables

## Testing
- `swift --version`
- `swift test` *(fails: `Could not find Package.swift`)*