### PR TITLE
Add dungeon map view

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @State private var pendingInteractableID: String?
     @State private var selectedCharacterID: UUID? // Track selected character
     @State private var showingStatusSheet = false // Controls the party sheet
+    @State private var showingMap = false // Controls the map sheet
     @State private var doorProgress: CGFloat = 0 // For sliding door transition
 
     init() {
@@ -122,6 +123,15 @@ struct ContentView: View {
                     }
                     .padding()
                     .background(.thinMaterial, in: Capsule())
+
+                    Button {
+                        showingMap.toggle()
+                    } label: {
+                        Image(systemName: "map")
+                        Text("Map")
+                    }
+                    .padding()
+                    .background(.thinMaterial, in: Capsule())
                 }
                 .padding()
             }
@@ -148,6 +158,9 @@ struct ContentView: View {
         .sheet(isPresented: $showingStatusSheet) {
             StatusSheetView(viewModel: viewModel)
                 .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showingMap) {
+            MapView(viewModel: viewModel)
         }
         .ignoresSafeArea(.all, edges: .bottom)
     }

--- a/CardGame/MapView.swift
+++ b/CardGame/MapView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct MapView: View {
+    @ObservedObject var viewModel: GameViewModel
+
+    private func orderedNodes(from map: DungeonMap) -> [MapNode] {
+        var result: [MapNode] = []
+        var queue: [UUID] = [map.startingNodeID]
+        var visited: Set<UUID> = []
+        while let id = queue.first {
+            queue.removeFirst()
+            guard visited.insert(id).inserted else { continue }
+            if let node = map.nodes[id] {
+                result.append(node)
+                queue.append(contentsOf: node.connections.map { $0.toNodeID })
+            }
+        }
+        return result
+    }
+
+    private func isCurrentLocation(nodeID: UUID) -> Bool {
+        viewModel.gameState.characterLocations.values.contains(nodeID)
+    }
+
+    var body: some View {
+        NavigationStack {
+            GeometryReader { geo in
+                if let map = viewModel.gameState.dungeon {
+                    let nodes = orderedNodes(from: map)
+                    let spacing = geo.size.width / CGFloat(max(nodes.count, 1) + 1)
+                    ZStack {
+                        ForEach(Array(nodes.enumerated()), id: \.1.id) { index, node in
+                            let pos = CGPoint(x: spacing * CGFloat(index + 1), y: geo.size.height / 2)
+                            ForEach(node.connections, id: \.toNodeID) { conn in
+                                if let targetIdx = nodes.firstIndex(where: { $0.id == conn.toNodeID }) {
+                                    let target = CGPoint(x: spacing * CGFloat(targetIdx + 1), y: geo.size.height / 2)
+                                    Path { path in
+                                        path.move(to: pos)
+                                        path.addLine(to: target)
+                                    }
+                                    .stroke(Color.gray, lineWidth: 2)
+                                    .zIndex(0) // ensure connectors are beneath nodes
+                                }
+                            }
+                        }
+                        ForEach(Array(nodes.enumerated()), id: \.1.id) { index, node in
+                            let pos = CGPoint(x: spacing * CGFloat(index + 1), y: geo.size.height / 2)
+                            Circle()
+                                .fill(node.isDiscovered ? Color.blue : Color.gray.opacity(0.3))
+                                .frame(width: 30, height: 30)
+                                .position(pos)
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.green, lineWidth: 3)
+                                        .opacity(isCurrentLocation(nodeID: node.id) ? 1 : 0)
+                                        .frame(width: 36, height: 36)
+                                        .position(pos)
+                                )
+                                .zIndex(1) // draw nodes above connectors
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    Text("No Map")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .padding()
+            .navigationTitle("Dungeon Map")
+        }
+    }
+}
+
+struct MapView_Previews: PreviewProvider {
+    static var previews: some View {
+        MapView(viewModel: GameViewModel())
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `MapView` for viewing dungeon layout
- show a new Map button in the game HUD that opens this view
- ensure connector lines render beneath node circles

## Testing
- `swift test` *(fails: Could not find Package.swift)*