### PR TITLE
Implement modular scenario loader

### DIFF
--- a/CardGame/ContentLoader.swift
+++ b/CardGame/ContentLoader.swift
@@ -1,28 +1,59 @@
 import Foundation
 
+/// Basic information about a scenario.
+struct ScenarioManifest: Codable {
+    var id: String
+    var title: String
+    var description: String
+    var entryNode: String?
+}
+
 class ContentLoader {
+    /// Shared loader using the default scenario ("tomb").
     static let shared = ContentLoader()
 
+    let scenarioName: String
+    let scenarioManifest: ScenarioManifest?
     let interactableTemplates: [Interactable]
     let harmFamilies: [HarmFamily]
     let harmFamilyDict: [String: HarmFamily]
     let treasureTemplates: [Treasure]
 
-    private init() {
-        self.interactableTemplates = Self.load("interactables.json")
-        self.harmFamilies = Self.load("harm_families.json")
+    /// Initialize a loader for a specific scenario directory.
+    init(scenario: String = "tomb") {
+        self.scenarioName = scenario
+        self.scenarioManifest = Self.loadManifest(for: scenario)
+        self.interactableTemplates = Self.load("interactables.json", for: scenario)
+        self.harmFamilies = Self.load("harm_families.json", for: scenario)
         self.harmFamilyDict = Dictionary(uniqueKeysWithValues: harmFamilies.map { ($0.id, $0) })
-        self.treasureTemplates = Self.load("treasures.json")
+        self.treasureTemplates = Self.load("treasures.json", for: scenario)
     }
 
-    private static func load<T: Decodable>(_ filename: String) -> [T] {
-        // The JSON files are stored within the "Content" folder reference in the
-        // Xcode project. When bundled, this folder becomes a subdirectory in the
-        // app bundle, so we must specify it when looking up the resource.
-        guard let url = Bundle.main.url(forResource: filename,
-                                        withExtension: nil,
-                                        subdirectory: "Content") else {
-            print("Failed to locate \(filename)")
+    private static func url(for filename: String, scenario: String) -> URL? {
+        if let url = Bundle.main.url(forResource: filename,
+                                     withExtension: nil,
+                                     subdirectory: "Content/Scenarios/\(scenario)") {
+            return url
+        }
+        return Bundle.main.url(forResource: filename,
+                               withExtension: nil,
+                               subdirectory: "Content")
+    }
+
+    private static func loadManifest(for scenario: String) -> ScenarioManifest? {
+        guard let url = url(for: "scenario.json", scenario: scenario) else { return nil }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(ScenarioManifest.self, from: data)
+        } catch {
+            print("Failed to decode scenario.json for \(scenario): \(error)")
+            return nil
+        }
+    }
+
+    private static func load<T: Decodable>(_ filename: String, for scenario: String) -> [T] {
+        guard let url = url(for: filename, scenario: scenario) else {
+            print("Failed to locate \(filename) for scenario \(scenario)")
             return []
         }
         do {

--- a/Content/Scenarios/test_lab/harm_families.json
+++ b/Content/Scenarios/test_lab/harm_families.json
@@ -1,0 +1,39 @@
+{
+  "families": [
+    {
+      "id": "head_trauma",
+      "lesser": { "description": "Headache", "penalty": { "type": "actionPenalty", "actionType": "Study" } },
+      "moderate": { "description": "Migraine", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Brain Lightning", "penalty": { "type": "banAction", "actionType": "Study" } },
+      "fatal": { "description": "Head Explosion" }
+    },
+    {
+      "id": "leg_injury",
+      "lesser": { "description": "Twisted Ankle", "penalty": { "type": "actionPenalty", "actionType": "Finesse" } },
+      "moderate": { "description": "Torn Muscle", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Shattered Knee", "penalty": { "type": "banAction", "actionType": "Finesse" } },
+      "fatal": { "description": "Crippled Beyond Recovery" }
+    },
+    {
+      "id": "electric_shock",
+      "lesser": { "description": "Electric Jolt" },
+      "moderate": { "description": "Seared Nerves", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Nerve Damage", "penalty": { "type": "banAction", "actionType": "Tinker" } },
+      "fatal": { "description": "Heart Stops" }
+    },
+    {
+      "id": "mental_anguish",
+      "lesser": { "description": "Unease", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "moderate": { "description": "Fleeting Shadows", "penalty": { "type": "actionPenalty", "actionType": "Survey" } },
+      "severe": { "description": "Terror", "penalty": { "type": "reduceEffect" } },
+      "fatal": { "description": "Mind Broken" }
+    },
+    {
+      "id": "gear_damage",
+      "lesser": { "description": "Frayed Rope", "penalty": { "type": "actionPenalty", "actionType": "Finesse" } },
+      "moderate": { "description": "Broken Tools", "penalty": { "type": "banAction", "actionType": "Tinker" } },
+      "severe": { "description": "Lost Map", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "fatal": { "description": "Stranded and Helpless" }
+    }
+  ]
+}

--- a/Content/Scenarios/test_lab/interactables.json
+++ b/Content/Scenarios/test_lab/interactables.json
@@ -1,0 +1,252 @@
+{
+  "common_traps": [
+    {
+      "id": "template_pressure_plate",
+      "title": "Pressure Plate",
+      "description": "A slightly raised stone tile looks suspicious.",
+      "availableActions": [
+        {
+          "name": "Deftly step over it",
+          "actionType": "Finesse",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [
+              { "type": "removeInteractable", "id": "self" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "lesser", "familyId": "leg_injury" }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_cursed_idol",
+      "title": "Cursed Idol",
+      "description": "A small, unnerving idol of a forgotten god.",
+      "availableActions": [
+        {
+          "name": "Smash it",
+          "actionType": "Wreck",
+          "position": "desperate",
+          "effect": "great",
+          "outcomes": {
+            "success": [
+              { "type": "removeInteractable", "id": "self" },
+              { "type": "gainTreasure", "treasureId": "treasure_purified_idol_shard" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "head_trauma" }
+            ]
+          }
+        }
+      ]
+    }
+    ,
+    {
+      "id": "template_crumbling_ledge",
+      "title": "Crumbling Ledge",
+      "description": "A narrow ledge over a dark chasm. It looks unstable.",
+      "availableActions": [
+        {
+          "name": "Cross Carefully",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "standard",
+          "isGroupAction": true,
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [
+              { "type": "gainStress", "amount": 2 },
+              { "type": "sufferHarm", "level": "lesser", "familyId": "leg_injury" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" },
+              { "type": "tickClock", "clockName": "Chasm Peril", "amount": 2 }
+            ]
+          }
+        },
+        {
+          "name": "Test its Stability",
+          "actionType": "Survey",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_mysterious_whispers",
+      "title": "Mysterious Whispers",
+      "description": "Voices echo softly from unseen sources.",
+      "availableActions": [
+        {
+          "name": "Listen Closely",
+          "actionType": "Attune",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_map_fragment" } ],
+            "partial": [ { "type": "sufferHarm", "level": "lesser", "familyId": "mental_anguish" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "mental_anguish" } ]
+          }
+        },
+        {
+          "name": "Block Out Noise",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_jammed_lock",
+      "title": "Jammed Lock",
+      "description": "A sturdy door with a rusted mechanism.",
+      "availableActions": [
+        {
+          "name": "Pick the Lock",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_precise_tools" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Lockdown Approaches", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "gear_damage" } ]
+          }
+        },
+        {
+          "name": "Force it",
+          "actionType": "Wreck",
+          "position": "desperate",
+          "effect": "great",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_unstable_rune",
+      "title": "Unstable Rune",
+      "description": "A glowing rune pulsates with dangerous energy.",
+      "availableActions": [
+        {
+          "name": "Decode Glyphs",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Rune Overload", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Shatter it",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_hidden_niche",
+      "title": "Hidden Niche",
+      "description": "A faint outline hints at a recess in the wall.",
+      "availableActions": [
+        {
+          "name": "Search Carefully",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Finesse", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "tickClock", "clockName": "Chest Trap", "amount": 1 } ] } } ] } } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        },
+        {
+          "name": "Force it Open",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Wreck", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ] } } ] } } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    }
+  ],
+  "threats": [
+    {
+      "id": "threat_hungry_ghoul",
+      "title": "Hungry Ghoul",
+      "description": "A ravenous ghoul lurches from the shadows.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Drive it back",
+          "actionType": "Skirmish",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" } ]
+          }
+        },
+        {
+          "name": "Flee",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "tickClock", "clockName": "Ghoul Pursuit", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "threat_reactor_breach",
+      "title": "Reactor Breach",
+      "description": "Alarms blare as a reactor begins to overload.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Stabilize Reactor",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Evacuate",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 2 } ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Content/Scenarios/test_lab/scenario.json
+++ b/Content/Scenarios/test_lab/scenario.json
@@ -1,0 +1,6 @@
+{
+  "id": "test_lab",
+  "title": "Test Lab",
+  "description": "A sterile testing environment.",
+  "entryNode": "entry"
+}

--- a/Content/Scenarios/test_lab/treasures.json
+++ b/Content/Scenarios/test_lab/treasures.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "treasure_purified_idol_shard",
+    "name": "Purified Idol Shard",
+    "description": "A fragment of the idol, cleansed of its curse.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "Blessing of the Idol"
+    }
+  },
+  {
+    "id": "treasure_ancient_coin",
+    "name": "Ancient Coin",
+    "description": "A coin from a forgotten empire.",
+    "grantedModifier": {
+      "improveEffect": true,
+      "description": "Lucky Find"
+    }
+  },
+  {
+    "id": "treasure_steadying_herbs",
+    "name": "Steadying Herbs",
+    "description": "Chewing these calms the nerves, for a time.",
+    "grantedModifier": {
+      "improvePosition": true,
+      "uses": 1,
+      "description": "from Steadying Herbs"
+    }
+  },
+  {
+    "id": "treasure_precise_tools",
+    "name": "Set of Precise Tools",
+    "description": "Ideal instruments for delicate work.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Tinker",
+      "uses": 2,
+      "description": "from Precise Tools"
+    }
+  },
+  {
+    "id": "treasure_charmed_talisman",
+    "name": "Charmed Talisman",
+    "description": "Offers fleeting protection from dark thoughts.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Attune",
+      "uses": 1,
+      "description": "from Charmed Talisman"
+    }
+  },
+  {
+    "id": "treasure_map_fragment",
+    "name": "Map Fragment",
+    "description": "Hints at a secret room somewhere in the tomb.",
+    "grantedModifier": {
+      "improveEffect": true,
+      "uses": 1,
+      "description": "from Map Fragment"
+    }
+  }
+]

--- a/Content/Scenarios/tomb/harm_families.json
+++ b/Content/Scenarios/tomb/harm_families.json
@@ -1,0 +1,39 @@
+{
+  "families": [
+    {
+      "id": "head_trauma",
+      "lesser": { "description": "Headache", "penalty": { "type": "actionPenalty", "actionType": "Study" } },
+      "moderate": { "description": "Migraine", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Brain Lightning", "penalty": { "type": "banAction", "actionType": "Study" } },
+      "fatal": { "description": "Head Explosion" }
+    },
+    {
+      "id": "leg_injury",
+      "lesser": { "description": "Twisted Ankle", "penalty": { "type": "actionPenalty", "actionType": "Finesse" } },
+      "moderate": { "description": "Torn Muscle", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Shattered Knee", "penalty": { "type": "banAction", "actionType": "Finesse" } },
+      "fatal": { "description": "Crippled Beyond Recovery" }
+    },
+    {
+      "id": "electric_shock",
+      "lesser": { "description": "Electric Jolt" },
+      "moderate": { "description": "Seared Nerves", "penalty": { "type": "reduceEffect" } },
+      "severe": { "description": "Nerve Damage", "penalty": { "type": "banAction", "actionType": "Tinker" } },
+      "fatal": { "description": "Heart Stops" }
+    },
+    {
+      "id": "mental_anguish",
+      "lesser": { "description": "Unease", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "moderate": { "description": "Fleeting Shadows", "penalty": { "type": "actionPenalty", "actionType": "Survey" } },
+      "severe": { "description": "Terror", "penalty": { "type": "reduceEffect" } },
+      "fatal": { "description": "Mind Broken" }
+    },
+    {
+      "id": "gear_damage",
+      "lesser": { "description": "Frayed Rope", "penalty": { "type": "actionPenalty", "actionType": "Finesse" } },
+      "moderate": { "description": "Broken Tools", "penalty": { "type": "banAction", "actionType": "Tinker" } },
+      "severe": { "description": "Lost Map", "penalty": { "type": "increaseStressCost", "amount": 1 } },
+      "fatal": { "description": "Stranded and Helpless" }
+    }
+  ]
+}

--- a/Content/Scenarios/tomb/interactables.json
+++ b/Content/Scenarios/tomb/interactables.json
@@ -1,0 +1,252 @@
+{
+  "common_traps": [
+    {
+      "id": "template_pressure_plate",
+      "title": "Pressure Plate",
+      "description": "A slightly raised stone tile looks suspicious.",
+      "availableActions": [
+        {
+          "name": "Deftly step over it",
+          "actionType": "Finesse",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [
+              { "type": "removeInteractable", "id": "self" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "lesser", "familyId": "leg_injury" }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_cursed_idol",
+      "title": "Cursed Idol",
+      "description": "A small, unnerving idol of a forgotten god.",
+      "availableActions": [
+        {
+          "name": "Smash it",
+          "actionType": "Wreck",
+          "position": "desperate",
+          "effect": "great",
+          "outcomes": {
+            "success": [
+              { "type": "removeInteractable", "id": "self" },
+              { "type": "gainTreasure", "treasureId": "treasure_purified_idol_shard" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "head_trauma" }
+            ]
+          }
+        }
+      ]
+    }
+    ,
+    {
+      "id": "template_crumbling_ledge",
+      "title": "Crumbling Ledge",
+      "description": "A narrow ledge over a dark chasm. It looks unstable.",
+      "availableActions": [
+        {
+          "name": "Cross Carefully",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "standard",
+          "isGroupAction": true,
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [
+              { "type": "gainStress", "amount": 2 },
+              { "type": "sufferHarm", "level": "lesser", "familyId": "leg_injury" }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" },
+              { "type": "tickClock", "clockName": "Chasm Peril", "amount": 2 }
+            ]
+          }
+        },
+        {
+          "name": "Test its Stability",
+          "actionType": "Survey",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_mysterious_whispers",
+      "title": "Mysterious Whispers",
+      "description": "Voices echo softly from unseen sources.",
+      "availableActions": [
+        {
+          "name": "Listen Closely",
+          "actionType": "Attune",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_map_fragment" } ],
+            "partial": [ { "type": "sufferHarm", "level": "lesser", "familyId": "mental_anguish" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "mental_anguish" } ]
+          }
+        },
+        {
+          "name": "Block Out Noise",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_jammed_lock",
+      "title": "Jammed Lock",
+      "description": "A sturdy door with a rusted mechanism.",
+      "availableActions": [
+        {
+          "name": "Pick the Lock",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_precise_tools" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Lockdown Approaches", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "gear_damage" } ]
+          }
+        },
+        {
+          "name": "Force it",
+          "actionType": "Wreck",
+          "position": "desperate",
+          "effect": "great",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_unstable_rune",
+      "title": "Unstable Rune",
+      "description": "A glowing rune pulsates with dangerous energy.",
+      "availableActions": [
+        {
+          "name": "Decode Glyphs",
+          "actionType": "Study",
+          "position": "controlled",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "partial": [ { "type": "tickClock", "clockName": "Rune Overload", "amount": 1 } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Shatter it",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "template_hidden_niche",
+      "title": "Hidden Niche",
+      "description": "A faint outline hints at a recess in the wall.",
+      "availableActions": [
+        {
+          "name": "Search Carefully",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Finesse", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "tickClock", "clockName": "Chest Trap", "amount": 1 } ] } } ] } } ],
+            "failure": [ { "type": "gainStress", "amount": 1 } ]
+          }
+        },
+        {
+          "name": "Force it Open",
+          "actionType": "Wreck",
+          "position": "risky",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "addInteractable", "inNodeID": "current", "interactable": { "id": "template_small_chest", "title": "Small Chest", "description": "Dusty but intact.", "availableActions": [ { "name": "Open", "actionType": "Wreck", "position": "risky", "effect": "standard", "outcomes": { "success": [ { "type": "gainTreasure", "treasureId": "treasure_charmed_talisman" }, { "type": "removeInteractable", "id": "self" } ], "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ] } } ] } } ],
+            "failure": [ { "type": "sufferHarm", "level": "lesser", "familyId": "gear_damage" } ]
+          }
+        }
+      ]
+    }
+  ],
+  "threats": [
+    {
+      "id": "threat_hungry_ghoul",
+      "title": "Hungry Ghoul",
+      "description": "A ravenous ghoul lurches from the shadows.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Drive it back",
+          "actionType": "Skirmish",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "leg_injury" } ]
+          }
+        },
+        {
+          "name": "Flee",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "tickClock", "clockName": "Ghoul Pursuit", "amount": 1 } ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "threat_reactor_breach",
+      "title": "Reactor Breach",
+      "description": "Alarms blare as a reactor begins to overload.",
+      "isThreat": true,
+      "availableActions": [
+        {
+          "name": "Stabilize Reactor",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "sufferHarm", "level": "severe", "familyId": "electric_shock" } ]
+          }
+        },
+        {
+          "name": "Evacuate",
+          "actionType": "Finesse",
+          "position": "desperate",
+          "effect": "limited",
+          "outcomes": {
+            "success": [ { "type": "removeInteractable", "id": "self" } ],
+            "failure": [ { "type": "gainStress", "amount": 2 } ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Content/Scenarios/tomb/scenario.json
+++ b/Content/Scenarios/tomb/scenario.json
@@ -1,0 +1,6 @@
+{
+  "id": "tomb",
+  "title": "Forgotten Tomb",
+  "description": "Explore the depths of an ancient tomb.",
+  "entryNode": "start"
+}

--- a/Content/Scenarios/tomb/treasures.json
+++ b/Content/Scenarios/tomb/treasures.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "treasure_purified_idol_shard",
+    "name": "Purified Idol Shard",
+    "description": "A fragment of the idol, cleansed of its curse.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "Blessing of the Idol"
+    }
+  },
+  {
+    "id": "treasure_ancient_coin",
+    "name": "Ancient Coin",
+    "description": "A coin from a forgotten empire.",
+    "grantedModifier": {
+      "improveEffect": true,
+      "description": "Lucky Find"
+    }
+  },
+  {
+    "id": "treasure_steadying_herbs",
+    "name": "Steadying Herbs",
+    "description": "Chewing these calms the nerves, for a time.",
+    "grantedModifier": {
+      "improvePosition": true,
+      "uses": 1,
+      "description": "from Steadying Herbs"
+    }
+  },
+  {
+    "id": "treasure_precise_tools",
+    "name": "Set of Precise Tools",
+    "description": "Ideal instruments for delicate work.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Tinker",
+      "uses": 2,
+      "description": "from Precise Tools"
+    }
+  },
+  {
+    "id": "treasure_charmed_talisman",
+    "name": "Charmed Talisman",
+    "description": "Offers fleeting protection from dark thoughts.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "applicableToAction": "Attune",
+      "uses": 1,
+      "description": "from Charmed Talisman"
+    }
+  },
+  {
+    "id": "treasure_map_fragment",
+    "name": "Map Fragment",
+    "description": "Hints at a secret room somewhere in the tomb.",
+    "grantedModifier": {
+      "improveEffect": true,
+      "uses": 1,
+      "description": "from Map Fragment"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- support scenarios in `ContentLoader`
- load a `scenario.json` manifest from `Content/Scenarios/<scenario>`
- add sample `tomb` and `test_lab` scenario folders with content

## Testing
- `swift test` *(fails: Could not find Package.swift)*