### PR TITLE
Implement main menu and scenario selection

### DIFF
--- a/CardGame/CardGameApp.swift
+++ b/CardGame/CardGameApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct CardSwipeDemoApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainMenuView()
         }
     }
 }

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -9,8 +9,8 @@ struct ContentView: View {
     @State private var showingMap = false // Controls the map sheet
     @State private var doorProgress: CGFloat = 0 // For sliding door transition
 
-    init() {
-        let vm = GameViewModel()
+    init(scenario: String = "tomb") {
+        let vm = GameViewModel(scenario: scenario)
         _viewModel = StateObject(wrappedValue: vm)
         _selectedCharacterID = State(initialValue: vm.gameState.party.first?.id)
     }

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -30,9 +30,9 @@ class GameViewModel: ObservableObject {
     }
 
 
-    init() {
+    init(scenario: String = "tomb") {
         self.gameState = GameState()
-        startNewRun()
+        startNewRun(scenario: scenario)
     }
 
     // --- Core Logic Functions for the Sprint ---
@@ -352,9 +352,13 @@ class GameViewModel: ObservableObject {
         }
     }
 
-    /// Starts a brand new run, resetting the game state
-    func startNewRun() {
-        let generator = DungeonGenerator()
+    /// Starts a brand new run, resetting the game state. The scenario id
+    /// corresponds to a folder within `Content/Scenarios`.
+    func startNewRun(scenario: String = "tomb") {
+        // Recreate the shared content loader so subsequent lookups use the
+        // selected scenario.
+        ContentLoader.shared = ContentLoader(scenario: scenario)
+        let generator = DungeonGenerator(content: ContentLoader.shared)
         let (newDungeon, generatedClocks) = generator.generate(level: 1)
 
         self.gameState = GameState(

--- a/CardGame/MainMenuView.swift
+++ b/CardGame/MainMenuView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct MainMenuView: View {
+    @State private var showingScenarioSelect = false
+    @State private var startScenario: ScenarioManifest?
+    @State private var availableScenarios: [ScenarioManifest] = ContentLoader.availableScenarios()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("Temple of Terror")
+                    .font(.largeTitle)
+                    .bold()
+
+                Button("Start New Game") {
+                    startScenario = availableScenarios.first { $0.id == "tomb" } ?? availableScenarios.first
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Continue") { }
+                    .disabled(true)
+
+                Button("Scenario Select") {
+                    showingScenarioSelect = true
+                }
+                .buttonStyle(.bordered)
+
+                Button("Settings") { }
+                    .disabled(true)
+            }
+            .padding()
+            .navigationDestination(item: $startScenario) { manifest in
+                ContentView(scenario: manifest.id)
+            }
+            .sheet(isPresented: $showingScenarioSelect) {
+                ScenarioSelectView(available: availableScenarios) { manifest in
+                    startScenario = manifest
+                    showingScenarioSelect = false
+                }
+            }
+        }
+    }
+}
+
+private struct ScenarioSelectView: View {
+    var available: [ScenarioManifest]
+    var onSelect: (ScenarioManifest) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(available, id: \.id) { scenario in
+                VStack(alignment: .leading) {
+                    Text(scenario.title).font(.headline)
+                    Text(scenario.description).font(.subheadline)
+                }
+                .onTapGesture {
+                    onSelect(scenario)
+                    dismiss()
+                }
+            }
+            .navigationTitle("Scenarios")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct MainMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainMenuView()
+    }
+}

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -194,10 +194,10 @@ struct HarmState: Codable {
 /// Central catalog of all harm families available in the game.
 /// This dictionary is populated from the JSON content loaded by `ContentLoader`.
 struct HarmLibrary {
-    static let families: [String: HarmFamily] = {
-        let families = ContentLoader.shared.harmFamilies
-        return Dictionary(uniqueKeysWithValues: families.map { ($0.id, $0) })
-    }()
+    /// Access the harm families for the currently loaded scenario.
+    static var families: [String: HarmFamily] {
+        return ContentLoader.shared.harmFamilyDict
+    }
 }
 
 struct GameClock: Identifiable, Codable {


### PR DESCRIPTION
## Summary
- add `MainMenuView` to manage game start flow
- enable scenario selection by querying bundled scenarios
- reload shared `ContentLoader` when starting a new game
- adjust models and game view model to work with scenarios
- launch `MainMenuView` from `CardGameApp`

## Testing
- `swift test` *(fails: Could not find Package.swift)*