### PR TITLE
Implement save/load system

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -8,11 +8,17 @@ struct ContentView: View {
     @State private var showingStatusSheet = false // Controls the party sheet
     @State private var showingMap = false // Controls the map sheet
     @State private var doorProgress: CGFloat = 0 // For sliding door transition
+    @Environment(\.scenePhase) private var scenePhase
 
     init(scenario: String = "tomb") {
         let vm = GameViewModel(scenario: scenario)
         _viewModel = StateObject(wrappedValue: vm)
         _selectedCharacterID = State(initialValue: vm.gameState.party.first?.id)
+    }
+
+    init(viewModel: GameViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+        _selectedCharacterID = State(initialValue: viewModel.gameState.party.first?.id)
     }
 
     // Helper to retrieve the selected character object
@@ -163,6 +169,11 @@ struct ContentView: View {
             MapView(viewModel: viewModel)
         }
         .ignoresSafeArea(.all, edges: .bottom)
+        .onChange(of: scenePhase) { phase in
+            if phase != .active {
+                viewModel.saveGame()
+            }
+        }
     }
 }
 

--- a/CardGame/MainMenuView.swift
+++ b/CardGame/MainMenuView.swift
@@ -4,6 +4,8 @@ struct MainMenuView: View {
     @State private var showingScenarioSelect = false
     @State private var availableScenarios: [ScenarioManifest] = ContentLoader.availableScenarios()
     @State private var path = NavigationPath()
+    @State private var continueVM: GameViewModel?
+    @State private var continueActive = false
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -19,8 +21,14 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
 
-                Button("Continue") { }
-                    .disabled(true)
+                Button("Continue") {
+                    let vm = GameViewModel()
+                    if vm.loadGame() {
+                        continueVM = vm
+                        continueActive = true
+                    }
+                }
+                .disabled(!GameViewModel.saveExists)
 
                 Button("Scenario Select") {
                     showingScenarioSelect = true
@@ -34,6 +42,12 @@ struct MainMenuView: View {
             .navigationDestination(for: ScenarioManifest.self) { manifest in
                 ContentView(scenario: manifest.id)
             }
+            NavigationLink("", isActive: $continueActive) {
+                if let vm = continueVM {
+                    ContentView(viewModel: vm)
+                }
+            }
+            .hidden()
             .sheet(isPresented: $showingScenarioSelect) {
                 ScenarioSelectView(available: availableScenarios) { manifest in
                     path.append(manifest)

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -6,6 +6,10 @@ enum GameStatus: String, Codable {
 }
 
 struct GameState: Codable {
+    /// Identifier for the scenario that generated this run. Used when loading
+    /// to reinitialize the `ContentLoader` with the correct data bundle.
+    var scenarioName: String = "tomb"
+
     var party: [Character] = []
     var activeClocks: [GameClock] = []
     var dungeon: DungeonMap? // The full map
@@ -507,5 +511,21 @@ struct NodeConnection: Codable {
     var toNodeID: UUID
     var isUnlocked: Bool = true // A path could be locked initially
     var description: String // e.g., "A dark tunnel", "A rickety bridge"
+}
+
+// MARK: - Persistence Helpers
+
+extension GameState {
+    /// Encode the game state and write it to the specified URL.
+    func save(to url: URL) throws {
+        let data = try JSONEncoder().encode(self)
+        try data.write(to: url)
+    }
+
+    /// Load a `GameState` from the given file URL.
+    static func load(from url: URL) throws -> GameState {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(GameState.self, from: data)
+    }
 }
 


### PR DESCRIPTION
## Summary
- track `scenarioName` in `GameState`
- add persistence helpers on `GameState`
- save and load runs via `GameViewModel`
- auto-save on actions and scene phase changes
- hook Continue button into new save system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6839f2e08d38832bbb2554936599ac04