### PR TITLE
Fix save/load initialization and UUIDs

### DIFF
--- a/CardGame/CharacterSelectorView.swift
+++ b/CardGame/CharacterSelectorView.swift
@@ -21,8 +21,8 @@ struct CharacterSelectorView: View {
 struct CharacterSelectorView_Previews: PreviewProvider {
     static var previews: some View {
         CharacterSelectorView(characters: [
-            Character(name: "Indy", characterClass: "Archaeologist", stress: 0, harm: HarmState(), actions: ["Study": 3]),
-            Character(name: "Sallah", characterClass: "Brawler", stress: 0, harm: HarmState(), actions: ["Wreck": 2])
+            Character(id: UUID(), name: "Indy", characterClass: "Archaeologist", stress: 0, harm: HarmState(), actions: ["Study": 3]),
+            Character(id: UUID(), name: "Sallah", characterClass: "Brawler", stress: 0, harm: HarmState(), actions: ["Wreck": 2])
         ], selectedCharacterID: .constant(nil))
     }
 }

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     init(scenario: String = "tomb") {
-        let vm = GameViewModel(scenario: scenario)
+        let vm = GameViewModel(startNewWithScenario: scenario)
         _viewModel = StateObject(wrappedValue: vm)
         _selectedCharacterID = State(initialValue: vm.gameState.party.first?.id)
     }

--- a/CardGame/DungeonGenerator.swift
+++ b/CardGame/DungeonGenerator.swift
@@ -34,6 +34,7 @@ class DungeonGenerator {
             let theme = themes.randomElement()
 
             var newNode = MapNode(
+                id: UUID(),
                 name: "Forgotten Antechamber \(i + 1)",
                 soundProfile: soundProfiles.randomElement() ?? "silent_tomb",
                 interactables: [],

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -41,7 +41,13 @@ class GameViewModel: ObservableObject {
     }
 
 
-    init(scenario: String = "tomb") {
+    /// Initialize a blank view model intended for loading a game.
+    init() {
+        self.gameState = GameState()
+    }
+
+    /// Initialize and immediately start a new game with the given scenario.
+    init(startNewWithScenario scenario: String) {
         self.gameState = GameState()
         startNewRun(scenario: scenario)
     }
@@ -406,9 +412,9 @@ class GameViewModel: ObservableObject {
         self.gameState = GameState(
             scenarioName: scenario,
             party: [
-                Character(name: "Indy", characterClass: "Archaeologist", stress: 0, harm: HarmState(), actions: ["Study": 3, "Wreck": 1]),
-                Character(name: "Sallah", characterClass: "Brawler", stress: 0, harm: HarmState(), actions: ["Finesse": 2, "Survey": 2]),
-                Character(name: "Marion", characterClass: "Survivor", stress: 0, harm: HarmState(), actions: ["Tinker": 2, "Attune": 1])
+                Character(id: UUID(), name: "Indy", characterClass: "Archaeologist", stress: 0, harm: HarmState(), actions: ["Study": 3, "Wreck": 1]),
+                Character(id: UUID(), name: "Sallah", characterClass: "Brawler", stress: 0, harm: HarmState(), actions: ["Finesse": 2, "Survey": 2]),
+                Character(id: UUID(), name: "Marion", characterClass: "Survivor", stress: 0, harm: HarmState(), actions: ["Tinker": 2, "Attune": 1])
             ],
             activeClocks: [
                 GameClock(name: "The Guardian Wakes", segments: 6, progress: 0)

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -77,7 +77,7 @@ struct Treasure: Codable, Identifiable {
 }
 
 struct Character: Identifiable, Codable {
-    let id: UUID = UUID()
+    let id: UUID
     var name: String
     var characterClass: String
     var stress: Int
@@ -499,7 +499,7 @@ struct DungeonMap: Codable {
 
 // Represents a single room or location on the map
 struct MapNode: Identifiable, Codable {
-    let id: UUID = UUID()
+    let id: UUID
     var name: String
     var soundProfile: String
     var interactables: [Interactable]


### PR DESCRIPTION
## Summary
- create separate init paths for new games vs loading games
- stop overwriting saves when continuing
- ensure Character and MapNode IDs persist when loading
- pass explicit UUIDs when creating characters or nodes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683a1130d888832bad1b6d4fe61f0a31