### PR TITLE
Implement free actions for interactables

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -66,9 +66,13 @@ struct ContentView: View {
 
                                 ForEach(items, id: \.id) { interactable in
                                     InteractableCardView(interactable: interactable, selectedCharacter: selectedCharacter) { action in
-                                        if selectedCharacter != nil {
-                                            pendingAction = action
-                                            pendingInteractableID = interactable.id
+                                        if let character = selectedCharacter {
+                                            if action.requiresTest {
+                                                pendingAction = action
+                                                pendingInteractableID = interactable.id
+                                            } else {
+                                                _ = viewModel.performFreeAction(for: action, with: character, interactableID: interactable.id)
+                                            }
                                         }
                                     }
                                     .transition(.scale(scale: 0.9).combined(with: .opacity))

--- a/CardGame/DungeonGenerator.swift
+++ b/CardGame/DungeonGenerator.swift
@@ -86,6 +86,7 @@ class DungeonGenerator {
                         actionType: "Tinker",
                         position: .risky,
                         effect: .standard,
+                        requiresTest: false,
                         outcomes: [
                             .success: [
                                 .unlockConnection(fromNodeID: lock.from, toNodeID: lock.to),

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -164,6 +164,15 @@ class GameViewModel: ObservableObject {
         )
     }
 
+    /// Executes a free action that does not require a roll, applying its success
+    /// consequences immediately.
+    func performFreeAction(for action: ActionOption, with character: Character, interactableID: String?) -> String {
+        let consequences = action.outcomes[.success] ?? []
+        let description = processConsequences(consequences, forCharacter: character, interactableID: interactableID)
+        saveGame()
+        return description
+    }
+
     /// The main dice roll function, now returns the result for the UI.
     func performAction(for action: ActionOption, with character: Character, interactableID: String?) -> DiceRollResult {
         if action.isGroupAction {

--- a/CardGame/InteractableCardView.swift
+++ b/CardGame/InteractableCardView.swift
@@ -46,7 +46,8 @@ struct InteractableCardView: View {
                 .font(.body)
             Divider()
             ForEach(interactable.availableActions, id: \.name) { action in
-                Button(action.name) {
+                let title = action.requiresTest ? action.name : "\(action.name) (Auto)"
+                Button(title) {
                     onActionTapped(action)
                 }
                 .buttonStyle(.bordered)

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -262,11 +262,14 @@ struct ActionOption: Codable {
     var actionType: String // Corresponds to a key in Character.actions, e.g., "Tinker"
     var position: RollPosition
     var effect: RollEffect
+    /// Whether this action requires a dice roll. If false, success consequences
+    /// are applied immediately when tapped.
+    var requiresTest: Bool = true
     var isGroupAction: Bool = false
     var outcomes: [RollOutcome: [Consequence]] = [:]
 
     enum CodingKeys: String, CodingKey {
-        case name, actionType, position, effect, isGroupAction, outcomes
+        case name, actionType, position, effect, requiresTest, isGroupAction, outcomes
     }
 
     init(name: String,
@@ -274,11 +277,13 @@ struct ActionOption: Codable {
          position: RollPosition,
          effect: RollEffect,
          isGroupAction: Bool = false,
+         requiresTest: Bool = true,
          outcomes: [RollOutcome: [Consequence]] = [:]) {
         self.name = name
         self.actionType = actionType
         self.position = position
         self.effect = effect
+        self.requiresTest = requiresTest
         self.isGroupAction = isGroupAction
         self.outcomes = outcomes
     }
@@ -290,6 +295,7 @@ struct ActionOption: Codable {
         position = try container.decode(RollPosition.self, forKey: .position)
         effect = try container.decode(RollEffect.self, forKey: .effect)
         isGroupAction = try container.decodeIfPresent(Bool.self, forKey: .isGroupAction) ?? false
+        requiresTest = try container.decodeIfPresent(Bool.self, forKey: .requiresTest) ?? true
         let rawOutcomes = try container.decodeIfPresent([String: [Consequence]].self, forKey: .outcomes) ?? [:]
         var mapped: [RollOutcome: [Consequence]] = [:]
         for (key, value) in rawOutcomes {
@@ -306,6 +312,9 @@ struct ActionOption: Codable {
         try container.encode(actionType, forKey: .actionType)
         try container.encode(position, forKey: .position)
         try container.encode(effect, forKey: .effect)
+        if !requiresTest {
+            try container.encode(requiresTest, forKey: .requiresTest)
+        }
         if isGroupAction {
             try container.encode(isGroupAction, forKey: .isGroupAction)
         }

--- a/Content/Scenarios/test_lab/interactables.json
+++ b/Content/Scenarios/test_lab/interactables.json
@@ -190,6 +190,24 @@
         }
       ]
     }
+    ,
+    {
+      "id": "template_wall_switch",
+      "title": "Wall Switch",
+      "description": "A lever that seems safe to pull.",
+      "availableActions": [
+        {
+          "name": "Flip the switch",
+          "actionType": "Tinker",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_ancient_coin" }, { "type": "removeInteractable", "id": "self" } ]
+          }
+        }
+      ]
+    }
   ],
   "threats": [
     {

--- a/Content/Scenarios/tomb/interactables.json
+++ b/Content/Scenarios/tomb/interactables.json
@@ -190,6 +190,24 @@
         }
       ]
     }
+    ,
+    {
+      "id": "template_wall_switch",
+      "title": "Wall Switch",
+      "description": "A lever that seems safe to pull.",
+      "availableActions": [
+        {
+          "name": "Flip the switch",
+          "actionType": "Tinker",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_ancient_coin" }, { "type": "removeInteractable", "id": "self" } ]
+          }
+        }
+      ]
+    }
   ],
   "threats": [
     {


### PR DESCRIPTION
## Summary
- support non-test actions via new `requiresTest` flag on `ActionOption`
- show automatic actions in InteractableCardView
- execute free actions instantly in ContentView/GameViewModel
- make generated levers automatic and add wall switch examples to scenarios

## Testing
- `python3 -m json.tool < Content/Scenarios/test_lab/interactables.json > /dev/null`
- `python3 -m json.tool < Content/Scenarios/tomb/interactables.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_683a12ecf7e4832b8e005fbe5a578f3b