### PR TITLE
Implement tags system for treasures and actions

### DIFF
--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -114,11 +114,24 @@ struct CharacterSheetView: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 8) {
                             ForEach(character.treasures) { treasure in
-                                Text(treasure.name)
-                                    .font(.caption2)
-                                    .padding(4)
-                                    .background(Color(UIColor.systemBackground).opacity(0.5))
-                                    .cornerRadius(6)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(treasure.name)
+                                    if !treasure.tags.isEmpty {
+                                        HStack(spacing: 2) {
+                                            ForEach(treasure.tags, id: \.self) { tag in
+                                                Text(tag)
+                                                    .font(.caption3)
+                                                    .padding(2)
+                                                    .background(Color(UIColor.systemGray5))
+                                                    .cornerRadius(4)
+                                            }
+                                        }
+                                    }
+                                }
+                                .font(.caption2)
+                                .padding(4)
+                                .background(Color(UIColor.systemBackground).opacity(0.5))
+                                .cornerRadius(6)
                             }
                         }
                     }

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -444,6 +444,16 @@ class GameViewModel: ObservableObject {
         saveGame()
     }
 
+    /// Check if any party member possesses a treasure with the given tag.
+    func partyHasTreasureTag(_ tag: String) -> Bool {
+        for member in gameState.party {
+            for treasure in member.treasures {
+                if treasure.tags.contains(tag) { return true }
+            }
+        }
+        return false
+    }
+
 
     /// Move one or all party members depending on the current movement mode.
     func move(characterID: UUID, to connection: NodeConnection) {

--- a/CardGame/InteractableCardView.swift
+++ b/CardGame/InteractableCardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InteractableCardView: View {
+    @ObservedObject var viewModel: GameViewModel
     let interactable: Interactable
     let selectedCharacter: Character?
     let onActionTapped: (ActionOption) -> Void
@@ -38,12 +39,30 @@ struct InteractableCardView: View {
         return false
     }
 
+    private func actionDisabled(_ action: ActionOption) -> Bool {
+        if let tag = action.requiredTag {
+            return !viewModel.partyHasTreasureTag(tag)
+        }
+        return false
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(interactable.title)
                 .font(.title2).bold()
             Text(interactable.description)
                 .font(.body)
+            if !interactable.tags.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(interactable.tags, id: \.self) { tag in
+                        Text(tag)
+                            .font(.caption2)
+                            .padding(2)
+                            .background(Color(UIColor.systemGray5))
+                            .cornerRadius(4)
+                    }
+                }
+            }
             Divider()
             ForEach(interactable.availableActions, id: \.name) { action in
                 let title = action.requiresTest ? action.name : "\(action.name) (Auto)"
@@ -52,6 +71,7 @@ struct InteractableCardView: View {
                 }
                 .buttonStyle(.bordered)
                 .frame(maxWidth: .infinity)
+                .disabled(actionDisabled(action))
                 .overlay(alignment: .topTrailing) {
                     if hasPenalty(for: action) {
                         Image("icon_penalty_action")

--- a/Content/Scenarios/test_lab/interactables.json
+++ b/Content/Scenarios/test_lab/interactables.json
@@ -207,6 +207,25 @@
           }
         }
       ]
+    },
+    {
+      "id": "template_shadowy_corner",
+      "title": "Shadowy Corner",
+      "description": "Darkness conceals something here.",
+      "tags": ["Dark"],
+      "availableActions": [
+        {
+          "name": "Illuminate",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "requiredTag": "Light Source",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_ancient_coin" }, { "type": "removeInteractable", "id": "self" } ]
+          }
+        }
+      ]
     }
   ],
   "threats": [

--- a/Content/Scenarios/test_lab/treasures.json
+++ b/Content/Scenarios/test_lab/treasures.json
@@ -58,5 +58,15 @@
       "uses": 1,
       "description": "from Map Fragment"
     }
+  },
+  {
+    "id": "treasure_cursed_lantern",
+    "name": "Cursed Lantern",
+    "description": "An old lantern that glows with an eerie light.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "from Cursed Lantern"
+    },
+    "tags": ["Haunted", "Light Source"]
   }
 ]

--- a/Content/Scenarios/tomb/interactables.json
+++ b/Content/Scenarios/tomb/interactables.json
@@ -207,6 +207,25 @@
           }
         }
       ]
+    },
+    {
+      "id": "template_shadowy_corner",
+      "title": "Shadowy Corner",
+      "description": "Darkness conceals something here.",
+      "tags": ["Dark"],
+      "availableActions": [
+        {
+          "name": "Illuminate",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "requiredTag": "Light Source",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_ancient_coin" }, { "type": "removeInteractable", "id": "self" } ]
+          }
+        }
+      ]
     }
   ],
   "threats": [

--- a/Content/Scenarios/tomb/treasures.json
+++ b/Content/Scenarios/tomb/treasures.json
@@ -58,5 +58,15 @@
       "uses": 1,
       "description": "from Map Fragment"
     }
+  },
+  {
+    "id": "treasure_cursed_lantern",
+    "name": "Cursed Lantern",
+    "description": "An old lantern that glows with an eerie light.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "from Cursed Lantern"
+    },
+    "tags": ["Haunted", "Light Source"]
   }
 ]

--- a/Content/interactables.json
+++ b/Content/interactables.json
@@ -190,6 +190,26 @@
         }
       ]
     }
+    ,
+    {
+      "id": "template_shadowy_corner",
+      "title": "Shadowy Corner",
+      "description": "Darkness conceals something here.",
+      "tags": ["Dark"],
+      "availableActions": [
+        {
+          "name": "Illuminate",
+          "actionType": "Survey",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "requiredTag": "Light Source",
+          "outcomes": {
+            "success": [ { "type": "gainTreasure", "treasureId": "treasure_ancient_coin" }, { "type": "removeInteractable", "id": "self" } ]
+          }
+        }
+      ]
+    }
   ],
   "threats": [
     {

--- a/Content/treasures.json
+++ b/Content/treasures.json
@@ -58,5 +58,15 @@
       "uses": 1,
       "description": "from Map Fragment"
     }
+  },
+  {
+    "id": "treasure_cursed_lantern",
+    "name": "Cursed Lantern",
+    "description": "An old lantern that glows with an eerie light.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "from Cursed Lantern"
+    },
+    "tags": ["Haunted", "Light Source"]
   }
 ]

--- a/ContentDesign/Tags.md
+++ b/ContentDesign/Tags.md
@@ -1,0 +1,33 @@
+# Treasure and Interactable Tags
+
+Treasures and interactables can include a `tags` array in their JSON definition.
+Tags are simple strings used by scenario logic to unlock or modify actions.
+
+Example treasure entry:
+```json
+{
+  "id": "treasure_cursed_lantern",
+  "name": "Cursed Lantern",
+  "description": "An old lantern that glows with an eerie light.",
+  "grantedModifier": { "bonusDice": 1, "description": "from Cursed Lantern" },
+  "tags": ["Haunted", "Light Source"]
+}
+```
+
+## Gating Actions
+`ActionOption` now supports a `requiredTag` field. When set, the action
+button is enabled only if any party member possesses a treasure with that tag.
+
+Example snippet:
+```json
+{
+  "name": "Illuminate",
+  "actionType": "Survey",
+  "position": "controlled",
+  "effect": "standard",
+  "requiresTest": false,
+  "requiredTag": "Light Source",
+  "outcomes": { "success": [ { "type": "removeInteractable", "id": "self" } ] }
+}
+```
+Use tags to gate hidden options or trigger special consequences.


### PR DESCRIPTION
## Summary
- support tags in `Treasure` and `Interactable`
- gate actions with new `requiredTag` field
- show tag chips in interactables and character sheet
- add a sample `Cursed Lantern` treasure with tags
- add a `Shadowy Corner` interactable that requires a tag
- document how to use tags in `ContentDesign/Tags.md`

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project CardGame.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a18a9d304832bb4e8e9c894d37f4a