### PR TITLE
Implement ticket 3 docs and examples

### DIFF
--- a/Content/interactables.json
+++ b/Content/interactables.json
@@ -209,6 +209,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "template_locked_door",
+      "title": "Locked Door",
+      "description": "A heavy door with a silver keyhole.",
+      "tags": ["Door"],
+      "availableActions": [
+        {
+          "name": "Use Silver Key",
+          "actionType": "Tinker",
+          "position": "controlled",
+          "effect": "standard",
+          "requiresTest": false,
+          "requiredTag": "Key",
+          "outcomes": { "success": [ { "type": "removeInteractable", "id": "self" } ] }
+        }
+      ]
     }
   ],
   "threats": [

--- a/Content/treasures.json
+++ b/Content/treasures.json
@@ -68,5 +68,15 @@
       "description": "from Cursed Lantern"
     },
     "tags": ["Haunted", "Light Source"]
+  },
+  {
+    "id": "treasure_silver_key",
+    "name": "Silver Key",
+    "description": "Opens a locked door somewhere in the tomb.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "description": "from Silver Key"
+    },
+    "tags": ["Key"]
   }
 ]

--- a/ContentDesign/ContentSchemas.md
+++ b/ContentDesign/ContentSchemas.md
@@ -1,0 +1,52 @@
+# Content JSON Schemas
+
+This document describes key fields used in the JSON content files.
+
+## ActionOption
+
+`ActionOption` objects appear in `interactables.json` under each interactable's `availableActions` array.
+
+```json
+{
+  "name": "Pull Lever",
+  "actionType": "Tinker",
+  "position": "controlled",
+  "effect": "standard",
+  "requiresTest": false,
+  "outcomes": { "success": [ { "type": "removeInteractable", "id": "self" } ] }
+}
+```
+
+* `requiresTest` — Optional `Bool`. Defaults to `true`. If `false`, the action executes its `success` consequences immediately without a dice roll.
+
+## Treasure
+
+Treasure entries live in `treasures.json`.
+
+```json
+{
+  "id": "treasure_silver_key",
+  "name": "Silver Key",
+  "description": "Opens a locked door somewhere in the tomb.",
+  "grantedModifier": { "bonusDice": 1, "description": "from Silver Key" },
+  "tags": ["Key"]
+}
+```
+
+* `tags` — Optional array of strings used by scenario logic. Leave empty if the treasure does not provide any special tags.
+
+## Interactable
+
+Interactables in `interactables.json` may also define `tags`.
+
+```json
+{
+  "id": "template_locked_door",
+  "title": "Locked Door",
+  "description": "A heavy door with a silver keyhole.",
+  "tags": ["Door"],
+  "availableActions": [ /* ActionOption objects */ ]
+}
+```
+
+* `tags` — Optional array of strings describing properties scenario logic can query.

--- a/ContentDesign/Tags.md
+++ b/ContentDesign/Tags.md
@@ -31,3 +31,12 @@ Example snippet:
 }
 ```
 Use tags to gate hidden options or trigger special consequences.
+
+## Checking Tags in Scenario Code
+Use the view model's helper to query the party's treasures:
+```swift
+if viewModel.partyHasTreasureTag("Key") {
+    // unlock a branch or reveal a secret
+}
+```
+This allows scenarios to react dynamically to items the players have found.


### PR DESCRIPTION
## Summary
- document JSON fields for `requiresTest` and `tags`
- show how to query treasure tags in scenario logic
- add tagged treasure example
- add locked door interactable using free action and required tag

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683a1dbb5060832ba2ab72ce9b3ac7fe