### PR TITLE
Fix InteractableCardView invocation

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -65,7 +65,9 @@ struct ContentView: View {
                                 let items = threats.isEmpty ? node.interactables : threats
 
                                 ForEach(items, id: \.id) { interactable in
-                                    InteractableCardView(interactable: interactable, selectedCharacter: selectedCharacter) { action in
+                                    InteractableCardView(viewModel: viewModel,
+                                                        interactable: interactable,
+                                                        selectedCharacter: selectedCharacter) { action in
                                         if let character = selectedCharacter {
                                             if action.requiresTest {
                                                 pendingAction = action


### PR DESCRIPTION
## Summary
- fix missing `viewModel` argument when creating `InteractableCardView`

## Testing
- `./dump_project_structure.sh`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683a20a8e644832b8d8f545d3eef145a