### PR TITLE
Add treasure tooltips

### DIFF
--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CharacterSheetView: View {
     let character: Character
     var locationName: String? = nil
+    @State private var selectedTreasure: Treasure? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -114,24 +115,29 @@ struct CharacterSheetView: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 8) {
                             ForEach(character.treasures) { treasure in
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(treasure.name)
-                                    if !treasure.tags.isEmpty {
-                                        HStack(spacing: 2) {
-                                            ForEach(treasure.tags, id: \.self) { tag in
-                                                Text(tag)
-                                                    .font(.caption2)
-                                                    .padding(2)
-                                                    .background(Color(UIColor.systemGray5))
-                                                    .cornerRadius(4)
+                                Button {
+                                    selectedTreasure = treasure
+                                } label: {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(treasure.name)
+                                        if !treasure.tags.isEmpty {
+                                            HStack(spacing: 2) {
+                                                ForEach(treasure.tags, id: \.self) { tag in
+                                                    Text(tag)
+                                                        .font(.caption2)
+                                                        .padding(2)
+                                                        .background(Color(UIColor.systemGray5))
+                                                        .cornerRadius(4)
+                                                }
                                             }
                                         }
                                     }
+                                    .font(.caption2)
+                                    .padding(4)
+                                    .background(Color(UIColor.systemBackground).opacity(0.5))
+                                    .cornerRadius(6)
                                 }
-                                .font(.caption2)
-                                .padding(4)
-                                .background(Color(UIColor.systemBackground).opacity(0.5))
-                                .cornerRadius(6)
+                                .buttonStyle(.plain)
                             }
                         }
                     }
@@ -142,5 +148,8 @@ struct CharacterSheetView: View {
         .background(Color(UIColor.secondarySystemBackground))
         .cornerRadius(12)
         .shadow(radius: 3)
+        .popover(item: $selectedTreasure) { treasure in
+            TreasureTooltipView(treasure: treasure)
+        }
     }
 }

--- a/CardGame/TreasureTooltipView.swift
+++ b/CardGame/TreasureTooltipView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct TreasureTooltipView: View {
+    let treasure: Treasure
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(treasure.name)
+                .font(.headline)
+            Text(treasure.description)
+                .font(.body)
+            Text(treasure.grantedModifier.description)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            if !treasure.tags.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(treasure.tags, id: \.self) { tag in
+                        Text(tag)
+                            .font(.caption2)
+                            .padding(2)
+                            .background(Color(UIColor.systemGray5))
+                            .cornerRadius(4)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    TreasureTooltipView(
+        treasure: Treasure(
+            id: "demo",
+            name: "Lens of True Sight",
+            description: "Shows hidden things",
+            grantedModifier: Modifier(bonusDice: 1, description: "+1d to Survey"),
+            tags: ["Magic"]
+        )
+    )
+}


### PR DESCRIPTION
## Summary
- show treasure details via popover in CharacterSheetView
- add TreasureTooltipView for viewing details

## Testing
- `swiftc -parse CardGame/*.swift`

------
https://chatgpt.com/codex/tasks/task_e_683a2524e5ac832b9a30cec50f9ec593