### PR TITLE
Add harm tooltip popover

### DIFF
--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -4,6 +4,8 @@ struct CharacterSheetView: View {
     let character: Character
     var locationName: String? = nil
 
+    @State private var selectedHarm: HarmInfo?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Identity
@@ -46,37 +48,78 @@ struct CharacterSheetView: View {
                     // Lesser Harms
                     HStack(spacing: 4) {
                         ForEach(0..<HarmState.lesserSlots, id: \.self) { index in
-                            Text(index < character.harm.lesser.count ? character.harm.lesser[index].description : "None")
-                                .font(.caption2)
-                                .foregroundColor(index < character.harm.lesser.count ? .primary : .gray)
-                                .padding(4)
-                                .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                                .background(Color(UIColor.systemBackground))
-                                .cornerRadius(4)
+                            if index < character.harm.lesser.count {
+                                let harm = character.harm.lesser[index]
+                                Button {
+                                    selectedHarm = harmInfo(for: harm, level: .lesser)
+                                } label: {
+                                    Text(harm.description)
+                                        .font(.caption2)
+                                        .padding(4)
+                                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                                        .background(Color(UIColor.systemBackground))
+                                        .cornerRadius(4)
+                                }
+                            } else {
+                                Text("None")
+                                    .font(.caption2)
+                                    .foregroundColor(.gray)
+                                    .padding(4)
+                                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                                    .background(Color(UIColor.systemBackground))
+                                    .cornerRadius(4)
+                            }
                         }
                     }
 
                     // Moderate Harms
                     HStack(spacing: 4) {
                         ForEach(0..<HarmState.moderateSlots, id: \.self) { index in
-                            Text(index < character.harm.moderate.count ? character.harm.moderate[index].description : "None")
+                            if index < character.harm.moderate.count {
+                                let harm = character.harm.moderate[index]
+                                Button {
+                                    selectedHarm = harmInfo(for: harm, level: .moderate)
+                                } label: {
+                                    Text(harm.description)
+                                        .font(.caption2)
+                                        .padding(4)
+                                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                                        .background(Color(UIColor.systemBackground))
+                                        .cornerRadius(4)
+                                }
+                            } else {
+                                Text("None")
+                                    .font(.caption2)
+                                    .foregroundColor(.gray)
+                                    .padding(4)
+                                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                                    .background(Color(UIColor.systemBackground))
+                                    .cornerRadius(4)
+                            }
+                        }
+                    }
+
+                    // Severe Harm
+                    if let harm = character.harm.severe.first {
+                        Button {
+                            selectedHarm = harmInfo(for: harm, level: .severe)
+                        } label: {
+                            Text(harm.description)
                                 .font(.caption2)
-                                .foregroundColor(index < character.harm.moderate.count ? .primary : .gray)
                                 .padding(4)
                                 .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
                                 .background(Color(UIColor.systemBackground))
                                 .cornerRadius(4)
                         }
+                    } else {
+                        Text("None")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+                            .padding(4)
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                            .background(Color(UIColor.systemBackground))
+                            .cornerRadius(4)
                     }
-
-                    // Severe Harm
-                    Text(character.harm.severe.first?.description ?? "None")
-                        .font(.caption2)
-                        .foregroundColor(character.harm.severe.isEmpty ? .gray : .primary)
-                        .padding(4)
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                        .background(Color(UIColor.systemBackground))
-                        .cornerRadius(4)
                 }
                 .padding(.top, 8)
             }
@@ -142,5 +185,48 @@ struct CharacterSheetView: View {
         .background(Color(UIColor.secondarySystemBackground))
         .cornerRadius(12)
         .shadow(radius: 3)
+        .popover(item: $selectedHarm) { info in
+            VStack(alignment: .leading, spacing: 4) {
+                Text(info.title)
+                    .font(.headline)
+                Text(info.details)
+                    .font(.caption)
+            }
+            .padding()
+        }
     }
 }
+
+struct HarmInfo: Identifiable {
+    let id = UUID()
+    let title: String
+    let details: String
+}
+
+private func penaltyDescription(_ penalty: Penalty) -> String {
+    switch penalty {
+    case .reduceEffect:
+        return "All actions suffer -1 Effect."
+    case .increaseStressCost(let amount):
+        return "+\(amount) Stress cost to push or resist."
+    case .actionPenalty(let actionType):
+        return "-1d to \(actionType)."
+    case .banAction(let actionType):
+        return "Cannot perform \(actionType)."
+    }
+}
+
+private func harmInfo(for harm: (familyId: String, description: String), level: HarmLevel) -> HarmInfo {
+    if let family = HarmLibrary.families[harm.familyId] {
+        let tier: HarmTier
+        switch level {
+        case .lesser: tier = family.lesser
+        case .moderate: tier = family.moderate
+        case .severe: tier = family.severe
+        }
+        let penaltyText = tier.penalty.map { penaltyDescription($0) } ?? "No mechanical penalty."
+        return HarmInfo(title: "\(level.rawValue.capitalized) Harm: \(tier.description)", details: penaltyText)
+    }
+    return HarmInfo(title: harm.description, details: "")
+}
+


### PR DESCRIPTION
## Summary
- allow pressing harm entries in `CharacterSheetView`
- show a popover tooltip describing harm effects

## Testing
- `xcodebuild` not available in container

------
https://chatgpt.com/codex/tasks/task_e_683a2539433c832bba3d975d754025b9