### PR TITLE
Fix scrollView overlap with footer toolbar

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -100,25 +100,8 @@ struct ContentView: View {
                     .padding()
                     .animation(.default, value: viewModel.node(for: selectedCharacterID)?.id)
                 }
-            }
-            .disabled(viewModel.gameState.status == .gameOver)
-            .sheet(item: $pendingAction) { action in
-                if let character = selectedCharacter {
-                    let clockID = viewModel.gameState.activeClocks.first?.id
-                    DiceRollView(viewModel: viewModel,
-                                 action: action,
-                                 character: character,
-                                 clockID: clockID,
-                                 interactableID: pendingInteractableID)
-                } else {
-                    Text("No action selected")
-                }
-            }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            SlidingDoor(progress: doorProgress)
-
-            VStack {
-                Spacer()
                 HStack {
                     Button {
                         viewModel.toggleMovementMode()
@@ -150,6 +133,21 @@ struct ContentView: View {
                 }
                 .padding()
             }
+            .disabled(viewModel.gameState.status == .gameOver)
+            .sheet(item: $pendingAction) { action in
+                if let character = selectedCharacter {
+                    let clockID = viewModel.gameState.activeClocks.first?.id
+                    DiceRollView(viewModel: viewModel,
+                                 action: action,
+                                 character: character,
+                                 clockID: clockID,
+                                 interactableID: pendingInteractableID)
+                } else {
+                    Text("No action selected")
+                }
+            }
+
+            SlidingDoor(progress: doorProgress)
 
 
             if viewModel.gameState.status == .gameOver {
@@ -177,7 +175,6 @@ struct ContentView: View {
         .sheet(isPresented: $showingMap) {
             MapView(viewModel: viewModel)
         }
-        .ignoresSafeArea(.all, edges: .bottom)
         .onChange(of: scenePhase) { phase in
             if phase != .active {
                 viewModel.saveGame()


### PR DESCRIPTION
## Summary
- restructure `ContentView` layout so footer lives in the main `VStack`
- allow scroll view to take remaining space above the toolbar
- drop global `.ignoresSafeArea` usage so content respects safe area

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a2ea7eb34832b975f34bf08bdf389