### PR TITLE
Implement consequence gating logic

### DIFF
--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -564,6 +564,20 @@ enum RollPosition: String, Codable {
         case .controlled: return .controlled
         }
     }
+
+    /// Numeric ordering used for comparisons (desperate > risky > controlled).
+    var orderValue: Int {
+        switch self {
+        case .controlled: return 0
+        case .risky: return 1
+        case .desperate: return 2
+        }
+    }
+
+    /// Returns `true` if `self` is worse (>=) than the provided position.
+    func isWorseThanOrEqualTo(_ other: RollPosition) -> Bool {
+        return self.orderValue >= other.orderValue
+    }
 }
 
 enum RollEffect: String, Codable {
@@ -587,6 +601,20 @@ enum RollEffect: String, Codable {
         case .standard: return .great
         case .great: return .great
         }
+    }
+
+    /// Numeric ordering used for comparisons (great > standard > limited).
+    var orderValue: Int {
+        switch self {
+        case .limited: return 0
+        case .standard: return 1
+        case .great: return 2
+        }
+    }
+
+    /// Returns `true` if `self` is better (>=) than the provided effect.
+    func isBetterThanOrEqualTo(_ other: RollEffect) -> Bool {
+        return self.orderValue >= other.orderValue
     }
 }
 


### PR DESCRIPTION
## Summary
- compare position and effect levels with helper methods
- gate consequences with `areConditionsMet` in `GameViewModel`
- filter applied consequences based on conditions

## Testing
- `swiftc -parse CardGame/Models.swift CardGame/GameViewModel.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683a3739e998832b98b43bfe0c28325f