### PR TITLE
Add conditional consequence docs and example content

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -550,7 +550,8 @@ class GameViewModel: ObservableObject {
                 Character(id: UUID(), name: "Marion", characterClass: "Survivor", stress: 0, harm: HarmState(), actions: ["Tinker": 2, "Attune": 1])
             ],
             activeClocks: [
-                GameClock(name: "The Guardian Wakes", segments: 6, progress: 0)
+                GameClock(name: "The Guardian Wakes", segments: 6, progress: 0),
+                GameClock(name: "Test Clock", segments: 4, progress: 0)
             ] + generatedClocks,
             dungeon: newDungeon,
             characterLocations: [:],

--- a/Content/Scenarios/test_lab/interactables.json
+++ b/Content/Scenarios/test_lab/interactables.json
@@ -285,5 +285,51 @@
         }
       ]
     }
+  ],
+  "examples_dynamic": [
+    {
+      "id": "example_setpiece_machine",
+      "title": "Arcane Machine",
+      "description": "Cables snake from a humming device.",
+      "availableActions": [
+        {
+          "name": "Experiment with Device",
+          "actionType": "Study",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [
+              { "type": "gainTreasure", "treasureId": "treasure_test_gem" },
+              {
+                "type": "gainStress",
+                "amount": 1,
+                "conditions": [
+                  { "type": "clockProgress", "stringParam": "Test Clock", "intParam": 2 }
+                ]
+              },
+              {
+                "type": "gainTreasure",
+                "treasureId": "treasure_test_gem",
+                "conditions": [
+                  { "type": "characterHasTreasureId", "stringParam": "treasure_test_gem" }
+                ]
+              }
+            ],
+            "failure": [
+              { "type": "sufferHarm", "level": "moderate", "familyId": "electric_shock" },
+              { "type": "tickClock", "clockName": "Test Clock", "amount": 1 },
+              {
+                "type": "sufferHarm",
+                "level": "lesser",
+                "familyId": "electric_shock",
+                "conditions": [
+                  { "type": "characterHasTreasureId", "stringParam": "treasure_test_gem" }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
   ]
 }

--- a/Content/Scenarios/test_lab/treasures.json
+++ b/Content/Scenarios/test_lab/treasures.json
@@ -67,6 +67,13 @@
       "bonusDice": 1,
       "description": "from Cursed Lantern"
     },
-    "tags": ["Haunted", "Light Source"]
+  "tags": ["Haunted", "Light Source"]
+  },
+  {
+    "id": "treasure_test_gem",
+    "name": "Test Gem",
+    "description": "Glows with uncertain power.",
+    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem" },
+    "tags": ["Test"]
   }
 ]

--- a/Content/interactables.json
+++ b/Content/interactables.json
@@ -285,5 +285,41 @@
         }
       ]
     }
+  ],
+  "examples_dynamic": [
+    {
+      "id": "example_simple_lever",
+      "title": "Simple Lever",
+      "description": "A lever with warning signs.",
+      "availableActions": [
+        {
+          "name": "Throw the Lever",
+          "actionType": "Tinker",
+          "position": "risky",
+          "effect": "standard",
+          "outcomes": {
+            "success": [
+              {
+                "type": "gainTreasure",
+                "treasureId": "treasure_test_gem",
+                "conditions": [
+                  { "type": "requiresMinEffectLevel", "effectParam": "great" }
+                ]
+              }
+            ],
+            "failure": [
+              {
+                "type": "sufferHarm",
+                "level": "lesser",
+                "familyId": "gear_damage",
+                "conditions": [
+                  { "type": "requiresMinPositionLevel", "positionParam": "desperate" }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
   ]
 }

--- a/Content/treasures.json
+++ b/Content/treasures.json
@@ -77,6 +77,13 @@
       "bonusDice": 1,
       "description": "from Silver Key"
     },
-    "tags": ["Key"]
+  "tags": ["Key"]
+  },
+  {
+    "id": "treasure_test_gem",
+    "name": "Test Gem",
+    "description": "Glows with uncertain power.",
+    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem" },
+    "tags": ["Test"]
   }
 ]

--- a/ContentDesign/ContentSchemas.md
+++ b/ContentDesign/ContentSchemas.md
@@ -50,3 +50,41 @@ Interactables in `interactables.json` may also define `tags`.
 ```
 
 * `tags` — Optional array of strings describing properties scenario logic can query.
+
+## Consequence
+
+`Consequence` objects live inside the `outcomes` dictionaries for an `ActionOption`.
+
+```json
+{
+  "type": "gainStress",
+  "amount": 1,
+  "conditions": [
+    { "type": "requiresMinPositionLevel", "positionParam": "desperate" }
+  ]
+}
+```
+
+* `type` — The effect to apply (e.g. `gainStress`, `sufferHarm`, `tickClock`, `gainTreasure`).
+* Additional parameters such as `amount`, `level`, `familyId`, or `clockName` are included only when required by the chosen `type`.
+* `conditions` — Optional array of `GameCondition` objects. If provided, the consequence is only eligible when **all** conditions evaluate to true.
+
+Multiple consequences can be listed for a single outcome. A single entry forms a *shallow* pool while several entries form a *deeper* pool that the system can draw from based on roll quality.
+
+## GameCondition
+
+`GameCondition` objects gate consequences based on roll results or game state.
+
+```json
+{ "type": "requiresMinEffectLevel", "effectParam": "great" }
+```
+
+Available `type` values and their parameters:
+
+* `requiresMinEffectLevel` – `effectParam` (`limited|standard|great`)
+* `requiresExactEffectLevel` – `effectParam`
+* `requiresMinPositionLevel` – `positionParam` (`controlled|risky|desperate`)
+* `requiresExactPositionLevel` – `positionParam`
+* `characterHasTreasureId` – `stringParam` (treasure id)
+* `partyHasTreasureWithTag` – `stringParam` (treasure tag)
+* `clockProgress` – `stringParam` (clock name), `intParam` (min progress), optional `intParamMax` (max progress)


### PR DESCRIPTION
## Summary
- document Consequence conditions in ContentSchemas
- add simple and set-piece example interactables using new gating
- add test treasure for conditional gating
- initialize a `Test Clock` during startNewRun

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683a39ec55b4832ba9185028e5720a51