### PR TITLE
Fix Consequence helpers

### DIFF
--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -545,6 +545,22 @@ struct Consequence: Codable {
     }
 }
 
+extension Consequence {
+    /// Convenience constructor for unlocking a connection between two nodes.
+    static func unlockConnection(fromNodeID: UUID, toNodeID: UUID) -> Consequence {
+        var consequence = Consequence(kind: .unlockConnection)
+        consequence.fromNodeID = fromNodeID
+        consequence.toNodeID = toNodeID
+        return consequence
+    }
+
+    /// Convenience value used when an action removes the interactable that
+    /// triggered it.
+    static var removeSelfInteractable: Consequence {
+        Consequence(kind: .removeSelfInteractable)
+    }
+}
+
 enum HarmLevel: String, Codable {
     case lesser
     case moderate


### PR DESCRIPTION
## Summary
- add convenience builders for `Consequence`
- allow dungeon generator to compile when unlocking paths

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a3de07414832b9b04496ca4900e19