### PR TITLE
Add SceneKit dice tray foundation

### DIFF
--- a/CardGame/AssetPlaceholders/texture_dicetray_surface.md
+++ b/CardGame/AssetPlaceholders/texture_dicetray_surface.md
@@ -1,0 +1,2 @@
+# Placeholder Image: texture_dicetray_surface.png
+A subtle repeating texture for the 3D dice tray surface. 512x512 pixels and tileable.

--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -133,19 +133,8 @@ struct DiceRollView: View {
             }
 
             VStack(spacing: 20) {
-                HStack(spacing: 10) {
-                    let totalDice = diceValues.count
-                    ForEach(0..<totalDice, id: \.self) { index in
-                        Image(systemName: "die.face.\(diceValues[index]).fill")
-                            .font(.largeTitle)
-                            .foregroundColor(index >= (totalDice - extraDiceFromPush) ? .cyan : .primary)
-                            .rotationEffect(.degrees(diceRotations.indices.contains(index) ? diceRotations[index] : 0))
-                            .offset(diceOffsets.indices.contains(index) ? diceOffsets[index] : .zero)
-                            .opacity(fadeOthers && index != highlightIndex ? 0.5 : 1.0)
-                            .scaleEffect(index == highlightIndex ? popScale : 1.0)
-                            .shadow(color: index == highlightIndex ? .cyan : .clear, radius: index == highlightIndex ? 10 : 0)
-                    }
-                }
+                SceneKitDiceView(diceCount: diceValues.count)
+                    .frame(height: 200)
 
                 if result == nil {
                     Button {

--- a/CardGame/SceneKitDiceView.swift
+++ b/CardGame/SceneKitDiceView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import SceneKit
+
+struct SceneKitDiceView: UIViewRepresentable {
+    let diceCount: Int
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        let scene = SCNScene()
+        scnView.scene = scene
+
+        // Camera looking down into the tray
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.position = SCNVector3(x: 0, y: 5, z: 5)
+        cameraNode.eulerAngles = SCNVector3(-Float.pi / 4, 0, 0)
+        scene.rootNode.addChildNode(cameraNode)
+
+        // Ambient light
+        let ambient = SCNLight()
+        ambient.type = .ambient
+        ambient.intensity = 500
+        let ambientNode = SCNNode()
+        ambientNode.light = ambient
+        scene.rootNode.addChildNode(ambientNode)
+
+        // Omnidirectional light
+        let omni = SCNLight()
+        omni.type = .omni
+        omni.intensity = 1000
+        let omniNode = SCNNode()
+        omniNode.position = SCNVector3(0, 5, 5)
+        omniNode.light = omni
+        scene.rootNode.addChildNode(omniNode)
+
+        // Tray floor
+        let floor = SCNBox(width: 10, height: 0.2, length: 10, chamferRadius: 0)
+        floor.firstMaterial?.diffuse.contents = UIImage(named: "texture_dicetray_surface")
+        let floorNode = SCNNode(geometry: floor)
+        floorNode.position = SCNVector3(0, -0.1, 0)
+        floorNode.physicsBody = SCNPhysicsBody.static()
+        scene.rootNode.addChildNode(floorNode)
+
+        scnView.isPlaying = true
+        scnView.allowsCameraControl = true
+
+        scene.physicsWorld.gravity = SCNVector3(0, -9.8, 0)
+
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        // Future updates will add dice here
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `SceneKitDiceView` to host `SCNView` with camera, lighting and tray
- show `SceneKitDiceView` in `DiceRollView`
- add placeholder description for tray texture

## Testing
- `swift --version`
- `swiftc -emit-sil -o /tmp/out.swift CardGame/SceneKitDiceView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683e3bf44e74832bab4ecd5edda0fb0f