### PR TITLE
Implement basic 3D dice rolling

### DIFF
--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -21,6 +21,8 @@ struct DiceRollView: View {
     @State private var showOutcome = false
     @State private var showVignette = false
 
+    @StateObject private var diceController = SceneKitDiceController()
+
     @State private var shakeTimer: Timer? = nil
 
     @Environment(\.dismiss) var dismiss
@@ -133,7 +135,7 @@ struct DiceRollView: View {
             }
 
             VStack(spacing: 20) {
-                SceneKitDiceView(diceCount: diceValues.count)
+                SceneKitDiceView(controller: diceController, diceCount: diceValues.count)
                     .frame(height: 200)
 
                 if result == nil {
@@ -158,6 +160,7 @@ struct DiceRollView: View {
                 Button("Roll the Dice!") {
                     isRolling = true
                     startShaking()
+                    diceController.rollDice()
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)

--- a/CardGame/DieNode.swift
+++ b/CardGame/DieNode.swift
@@ -13,6 +13,15 @@ class DieNode {
                 container.addChildNode(child.clone())
             }
             container.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
+            let shape = SCNPhysicsShape(node: container, options: [SCNPhysicsShape.Option.type: SCNPhysicsShape.ShapeType.convexHull])
+            let body = SCNPhysicsBody(type: .dynamic, shape: shape)
+            body.mass = 1.0
+            body.friction = 0.8
+            body.restitution = 0.2
+            body.rollingFriction = 0.5
+            body.damping = 0.5
+            body.angularDamping = 0.8
+            container.physicsBody = body
             self.node = container
         } else {
             // Fallback to an empty node if the model can't be loaded
@@ -20,5 +29,13 @@ class DieNode {
             node.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
             self.node = node
         }
+    }
+
+    func prepareForRoll(at position: SCNVector3) {
+        node.position = position
+        node.eulerAngles = SCNVector3Zero
+        node.physicsBody?.clearAllForces()
+        node.physicsBody?.velocity = SCNVector3Zero
+        node.physicsBody?.angularVelocity = SCNVector4Zero
     }
 }

--- a/CardGame/SceneKitDiceView.swift
+++ b/CardGame/SceneKitDiceView.swift
@@ -1,16 +1,25 @@
 import SwiftUI
 import SceneKit
 
+class SceneKitDiceController: ObservableObject {
+    fileprivate var dice: [DieNode] = []
+
+    func rollDice() {
+        for (index, die) in dice.enumerated() {
+            let spread = Float(index) - Float(dice.count - 1) / 2
+            let pos = SCNVector3(spread * 1.2 + Float.random(in: -0.2...0.2), 1.0, Float.random(in: -0.2...0.2))
+            die.prepareForRoll(at: pos)
+            let force = SCNVector3(Float.random(in: -2...2), Float.random(in: 5...9), Float.random(in: -2...2))
+            die.node.physicsBody?.applyForce(force, asImpulse: true)
+            let torque = SCNVector4(Float.random(in: -1...1), Float.random(in: -1...1), Float.random(in: -1...1), Float.random(in: -3...3))
+            die.node.physicsBody?.applyTorque(torque, asImpulse: true)
+        }
+    }
+}
+
 struct SceneKitDiceView: UIViewRepresentable {
+    @ObservedObject var controller: SceneKitDiceController
     let diceCount: Int
-
-    class Coordinator {
-        var dice: [DieNode] = []
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
@@ -63,7 +72,7 @@ struct SceneKitDiceView: UIViewRepresentable {
                 Float.random(in: -4...4)
             )
             scene.rootNode.addChildNode(die.node)
-            context.coordinator.dice.append(die)
+            controller.dice.append(die)
         }
 
         return scnView
@@ -72,8 +81,8 @@ struct SceneKitDiceView: UIViewRepresentable {
     func updateUIView(_ uiView: SCNView, context: Context) {
         guard let scene = uiView.scene else { return }
 
-        if context.coordinator.dice.count < diceCount {
-            for _ in context.coordinator.dice.count..<diceCount {
+        if controller.dice.count < diceCount {
+            for _ in controller.dice.count..<diceCount {
                 let die = DieNode()
                 die.node.position = SCNVector3(
                     Float.random(in: -4...4),
@@ -81,11 +90,11 @@ struct SceneKitDiceView: UIViewRepresentable {
                     Float.random(in: -4...4)
                 )
                 scene.rootNode.addChildNode(die.node)
-                context.coordinator.dice.append(die)
+                controller.dice.append(die)
             }
-        } else if context.coordinator.dice.count > diceCount {
-            while context.coordinator.dice.count > diceCount {
-                let die = context.coordinator.dice.removeLast()
+        } else if controller.dice.count > diceCount {
+            while controller.dice.count > diceCount {
+                let die = controller.dice.removeLast()
                 die.node.removeFromParentNode()
             }
         }


### PR DESCRIPTION
## Summary
- add physics bodies to DieNode and helper to reset before a roll
- implement `SceneKitDiceController` and hook SceneKitDiceView up to it
- integrate controller with DiceRollView and trigger dice roll on button tap

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e42c7bca8832bbcaa6971a9c01350