### PR TITLE
Fix SceneKit dice collisions and tray orientation

### DIFF
--- a/CardGame/DieNode.swift
+++ b/CardGame/DieNode.swift
@@ -15,6 +15,7 @@ class DieNode {
             container.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
             let shape = SCNPhysicsShape(node: container, options: [SCNPhysicsShape.Option.type: SCNPhysicsShape.ShapeType.convexHull])
             let body = SCNPhysicsBody(type: .dynamic, shape: shape)
+            body.continuousCollisionDetectionThreshold = 0.001
             body.mass = 1.0
             body.friction = 0.8
             body.restitution = 0.2

--- a/CardGame/SceneKitDiceView.swift
+++ b/CardGame/SceneKitDiceView.swift
@@ -20,17 +20,18 @@ class SceneKitDiceController: ObservableObject {
 struct SceneKitDiceView: UIViewRepresentable {
     @ObservedObject var controller: SceneKitDiceController
     let diceCount: Int
+    private let traySize: Float = 10
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
         let scene = SCNScene()
         scnView.scene = scene
 
-        // Camera looking down into the tray
+        // Camera looking straight down into the tray
         let cameraNode = SCNNode()
         cameraNode.camera = SCNCamera()
-        cameraNode.position = SCNVector3(x: 0, y: 5, z: 5)
-        cameraNode.eulerAngles = SCNVector3(-Float.pi / 4, 0, 0)
+        cameraNode.position = SCNVector3(x: 0, y: 6, z: 0)
+        cameraNode.eulerAngles = SCNVector3(-Float.pi / 2, 0, 0)
         scene.rootNode.addChildNode(cameraNode)
 
         // Ambient light
@@ -51,15 +52,44 @@ struct SceneKitDiceView: UIViewRepresentable {
         scene.rootNode.addChildNode(omniNode)
 
         // Tray floor
-        let floor = SCNBox(width: 10, height: 0.2, length: 10, chamferRadius: 0)
+        let floor = SCNBox(width: CGFloat(traySize), height: 0.2, length: CGFloat(traySize), chamferRadius: 0)
         floor.firstMaterial?.diffuse.contents = UIImage(named: "texture_dicetray_surface")
         let floorNode = SCNNode(geometry: floor)
         floorNode.position = SCNVector3(0, -0.1, 0)
         floorNode.physicsBody = SCNPhysicsBody.static()
         scene.rootNode.addChildNode(floorNode)
 
+        // Tray walls to keep dice contained
+        let wallThickness: Float = 0.2
+        let wallHeight: Float = 2
+        let wallGeometry = SCNBox(width: CGFloat(traySize), height: CGFloat(wallHeight), length: CGFloat(wallThickness), chamferRadius: 0)
+        wallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
+
+        let backWall = SCNNode(geometry: wallGeometry)
+        backWall.position = SCNVector3(0, wallHeight/2 - 0.1, -traySize/2)
+        backWall.physicsBody = SCNPhysicsBody.static()
+        scene.rootNode.addChildNode(backWall)
+
+        let frontWall = SCNNode(geometry: wallGeometry)
+        frontWall.position = SCNVector3(0, wallHeight/2 - 0.1, traySize/2)
+        frontWall.physicsBody = SCNPhysicsBody.static()
+        scene.rootNode.addChildNode(frontWall)
+
+        let sideWallGeometry = SCNBox(width: CGFloat(wallThickness), height: CGFloat(wallHeight), length: CGFloat(traySize), chamferRadius: 0)
+        sideWallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
+
+        let leftWall = SCNNode(geometry: sideWallGeometry)
+        leftWall.position = SCNVector3(-traySize/2, wallHeight/2 - 0.1, 0)
+        leftWall.physicsBody = SCNPhysicsBody.static()
+        scene.rootNode.addChildNode(leftWall)
+
+        let rightWall = SCNNode(geometry: sideWallGeometry)
+        rightWall.position = SCNVector3(traySize/2, wallHeight/2 - 0.1, 0)
+        rightWall.physicsBody = SCNPhysicsBody.static()
+        scene.rootNode.addChildNode(rightWall)
+
         scnView.isPlaying = true
-        scnView.allowsCameraControl = true
+        scnView.allowsCameraControl = false
 
         scene.physicsWorld.gravity = SCNVector3(0, -9.8, 0)
 
@@ -67,9 +97,9 @@ struct SceneKitDiceView: UIViewRepresentable {
         for _ in 0..<diceCount {
             let die = DieNode()
             die.node.position = SCNVector3(
-                Float.random(in: -4...4),
+                Float.random(in: -(traySize/2 - 1)...(traySize/2 - 1)),
                 1.0,
-                Float.random(in: -4...4)
+                Float.random(in: -(traySize/2 - 1)...(traySize/2 - 1))
             )
             scene.rootNode.addChildNode(die.node)
             controller.dice.append(die)
@@ -85,9 +115,9 @@ struct SceneKitDiceView: UIViewRepresentable {
             for _ in controller.dice.count..<diceCount {
                 let die = DieNode()
                 die.node.position = SCNVector3(
-                    Float.random(in: -4...4),
+                    Float.random(in: -(traySize/2 - 1)...(traySize/2 - 1)),
                     1.0,
-                    Float.random(in: -4...4)
+                    Float.random(in: -(traySize/2 - 1)...(traySize/2 - 1))
                 )
                 scene.rootNode.addChildNode(die.node)
                 controller.dice.append(die)


### PR DESCRIPTION
## Summary
- improve DieNode physics setup to avoid tunneling
- reposition the SceneKit camera for a top-down view and disable user rotation
- add static walls around the dice tray and adjust dice spawn positions

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683e4575dec8832b828491e1848eea46