### PR TITLE
Improve dice physics and tray visuals

### DIFF
--- a/CardGame/DieNode.swift
+++ b/CardGame/DieNode.swift
@@ -4,37 +4,60 @@ class DieNode {
     var node: SCNNode
     var value: Int = 1
     private let defaultScale: Float = 0.01
+    /// The final visual side length of the die after applying `defaultScale`.
+    /// Adjust this value to match the actual size of your USDZ model once scaled.
+    private let effectiveSideLength: CGFloat = 0.8
 
     init() {
         if let sceneURL = Bundle.main.url(forResource: "dice", withExtension: "usdz"),
            let diceScene = try? SCNScene(url: sceneURL, options: nil) {
-            let container = SCNNode()
+            // Outer node will hold the physics body
+            self.node = SCNNode()
+
+            // Child node for the visual model
+            let visualNode = SCNNode()
             for child in diceScene.rootNode.childNodes {
-                container.addChildNode(child.clone())
+                visualNode.addChildNode(child.clone())
             }
-            container.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
-            let shape = SCNPhysicsShape(node: container, options: [SCNPhysicsShape.Option.type: SCNPhysicsShape.ShapeType.convexHull])
+            visualNode.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
+            self.node.addChildNode(visualNode)
+
+            // Simple cube physics shape matching the final scaled size
+            let cubeGeometry = SCNBox(
+                width: effectiveSideLength,
+                height: effectiveSideLength,
+                length: effectiveSideLength,
+                chamferRadius: effectiveSideLength * 0.1
+            )
+            let shape = SCNPhysicsShape(geometry: cubeGeometry, options: nil)
+
             let body = SCNPhysicsBody(type: .dynamic, shape: shape)
             body.continuousCollisionDetectionThreshold = 0.001
-            body.mass = 1.0
-            body.friction = 0.8
-            body.restitution = 0.2
-            body.rollingFriction = 0.5
-            body.damping = 0.5
-            body.angularDamping = 0.8
-            container.physicsBody = body
-            self.node = container
+            body.mass = 0.5
+            body.friction = 0.7
+            body.restitution = 0.1
+            body.rollingFriction = 0.6
+            body.damping = 0.15
+            body.angularDamping = 0.15
+
+            self.node.physicsBody = body
         } else {
             // Fallback to an empty node if the model can't be loaded
-            let node = SCNNode()
-            node.scale = SCNVector3(defaultScale, defaultScale, defaultScale)
-            self.node = node
+            self.node = SCNNode()
+            let fallbackBox = SCNBox(width: effectiveSideLength, height: effectiveSideLength, length: effectiveSideLength, chamferRadius: 0.05)
+            self.node.geometry = fallbackBox
+            print("Error: Could not load dice.usdz. Using fallback geometry.")
         }
     }
 
     func prepareForRoll(at position: SCNVector3) {
         node.position = position
-        node.eulerAngles = SCNVector3Zero
+        // Start each roll from a random orientation to avoid uniform results
+        node.eulerAngles = SCNVector3(
+            Float.random(in: 0...Float.pi * 2),
+            Float.random(in: 0...Float.pi * 2),
+            Float.random(in: 0...Float.pi * 2)
+        )
         node.physicsBody?.clearAllForces()
         node.physicsBody?.velocity = SCNVector3Zero
         node.physicsBody?.angularVelocity = SCNVector4Zero

--- a/CardGame/SceneKitDiceView.swift
+++ b/CardGame/SceneKitDiceView.swift
@@ -61,29 +61,43 @@ struct SceneKitDiceView: UIViewRepresentable {
 
         // Tray walls to keep dice contained
         let wallThickness: Float = 0.2
-        let wallHeight: Float = 2
-        let wallGeometry = SCNBox(width: CGFloat(traySize), height: CGFloat(wallHeight), length: CGFloat(wallThickness), chamferRadius: 0)
-        wallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
+        let wallHeight: Float = 2.0
+        let wallChamferRadius: CGFloat = 0.05
 
-        let backWall = SCNNode(geometry: wallGeometry)
+        // Geometry for front/back walls (top/bottom edges from camera perspective)
+        let frontBackWallGeometry = SCNBox(
+            width: CGFloat(traySize),
+            height: CGFloat(wallHeight),
+            length: CGFloat(wallThickness),
+            chamferRadius: wallChamferRadius
+        )
+        frontBackWallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
+
+        let backWall = SCNNode(geometry: frontBackWallGeometry)
         backWall.position = SCNVector3(0, wallHeight/2 - 0.1, -traySize/2)
         backWall.physicsBody = SCNPhysicsBody.static()
         scene.rootNode.addChildNode(backWall)
 
-        let frontWall = SCNNode(geometry: wallGeometry)
+        let frontWall = SCNNode(geometry: frontBackWallGeometry)
         frontWall.position = SCNVector3(0, wallHeight/2 - 0.1, traySize/2)
         frontWall.physicsBody = SCNPhysicsBody.static()
         scene.rootNode.addChildNode(frontWall)
 
-        let sideWallGeometry = SCNBox(width: CGFloat(wallThickness), height: CGFloat(wallHeight), length: CGFloat(traySize), chamferRadius: 0)
-        sideWallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
+        // Geometry for left/right walls
+        let leftRightWallGeometry = SCNBox(
+            width: CGFloat(wallThickness),
+            height: CGFloat(wallHeight),
+            length: CGFloat(traySize),
+            chamferRadius: wallChamferRadius
+        )
+        leftRightWallGeometry.firstMaterial?.diffuse.contents = floor.firstMaterial?.diffuse.contents
 
-        let leftWall = SCNNode(geometry: sideWallGeometry)
+        let leftWall = SCNNode(geometry: leftRightWallGeometry)
         leftWall.position = SCNVector3(-traySize/2, wallHeight/2 - 0.1, 0)
         leftWall.physicsBody = SCNPhysicsBody.static()
         scene.rootNode.addChildNode(leftWall)
 
-        let rightWall = SCNNode(geometry: sideWallGeometry)
+        let rightWall = SCNNode(geometry: leftRightWallGeometry)
         rightWall.position = SCNVector3(traySize/2, wallHeight/2 - 0.1, 0)
         rightWall.physicsBody = SCNPhysicsBody.static()
         scene.rootNode.addChildNode(rightWall)


### PR DESCRIPTION
## Summary
- stabilize dice physics using a simple cube shape
- randomize dice orientation before each roll
- chamfer tray wall edges for better lighting and containment

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683e55ef4a84832bb93056573875e76a