### PR TITLE
Implement ticket 6 of 3D dice visualization

### DIFF
--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -67,6 +67,7 @@ struct DiceRollView: View {
             }
         }
         fadeOthers = true
+        diceController.highlightDie(at: highlightIndex, fadeOthers: true)
         popDie()
         withAnimation(.spring(response: 0.4, dampingFraction: 0.5)) {
             showOutcome = true
@@ -132,7 +133,7 @@ struct DiceRollView: View {
             }
 
             VStack(spacing: 20) {
-                SceneKitDiceView(controller: diceController, diceCount: diceValues.count)
+                SceneKitDiceView(controller: diceController, diceCount: diceValues.count, pushedDice: extraDiceFromPush)
                     .frame(height: 200)
 
                 if result == nil {


### PR DESCRIPTION
## Summary
- support emitting highlights on SceneKit dice
- track pushed dice and highlight them in orange
- allow fading and highlighting dice from the dice controller
- use the highlight controller from `DiceRollView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1a22696c832bb05a7d62e218977f