### PR TITLE
Reorganize main dungeon view layout

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @State private var selectedCharacterID: UUID? // Track selected character
     @State private var showingStatusSheet = false // Controls the party sheet
     @State private var showingMap = false // Controls the map sheet
+    @State private var showingCharacterSheet = false // Controls the character drawer
     @State private var doorProgress: CGFloat = 0 // For sliding door transition
     @Environment(\.scenePhase) private var scenePhase
 
@@ -47,18 +48,13 @@ struct ContentView: View {
         ZStack {
             VStack(spacing: 0) {
                 HeaderView(
-                    title: viewModel.getNodeName(for: selectedCharacterID) ?? "Unknown Location",
-                    characters: viewModel.gameState.party,
-                    selectedCharacterID: $selectedCharacterID
+                    title: viewModel.getNodeName(for: selectedCharacterID) ?? "Unknown Location"
                 )
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
 
-                        if let character = selectedCharacter {
-                            CharacterSheetView(character: character)
-                            Divider()
-                        }
+
 
                         if let node = viewModel.node(for: selectedCharacterID) {
                             VStack(alignment: .leading, spacing: 16) {
@@ -102,36 +98,53 @@ struct ContentView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-                HStack {
-                    Button {
-                        viewModel.toggleMovementMode()
-                    } label: {
-                        Text("Movement: \(viewModel.partyMovementMode == .grouped ? "Grouped" : "Solo")")
-                    }
-                    .padding()
-                    .background(.thinMaterial, in: Capsule())
+                VStack(spacing: 8) {
+                    HStack {
+                        CharacterSelectorView(characters: viewModel.gameState.party,
+                                              selectedCharacterID: $selectedCharacterID)
 
-                    Spacer()
-
-                    Button {
-                        showingStatusSheet.toggle()
-                    } label: {
-                        Image(systemName: "person.3.fill")
-                        Text("Party")
+                        Button {
+                            showingCharacterSheet.toggle()
+                        } label: {
+                            Image(systemName: "chevron.up")
+                                .padding(6)
+                                .background(.thinMaterial, in: Circle())
+                        }
                     }
-                    .padding()
-                    .background(.thinMaterial, in: Capsule())
+                    .padding(.horizontal)
 
-                    Button {
-                        showingMap.toggle()
-                    } label: {
-                        Image(systemName: "map")
-                        Text("Map")
+                    HStack {
+                        Button {
+                            viewModel.toggleMovementMode()
+                        } label: {
+                            Text("Movement: \(viewModel.partyMovementMode == .grouped ? "Grouped" : "Solo")")
+                        }
+                        .padding()
+                        .background(.thinMaterial, in: Capsule())
+
+                        Spacer()
+
+                        Button {
+                            showingStatusSheet.toggle()
+                        } label: {
+                            Image(systemName: "person.3.fill")
+                            Text("Party")
+                        }
+                        .padding()
+                        .background(.thinMaterial, in: Capsule())
+
+                        Button {
+                            showingMap.toggle()
+                        } label: {
+                            Image(systemName: "map")
+                            Text("Map")
+                        }
+                        .padding()
+                        .background(.thinMaterial, in: Capsule())
                     }
-                    .padding()
-                    .background(.thinMaterial, in: Capsule())
+                    .padding(.horizontal)
                 }
-                .padding()
+                .padding(.vertical)
             }
             .disabled(viewModel.gameState.status == .gameOver)
             .sheet(item: $pendingAction) { action in
@@ -175,9 +188,24 @@ struct ContentView: View {
         .sheet(isPresented: $showingMap) {
             MapView(viewModel: viewModel)
         }
+        .sheet(isPresented: $showingCharacterSheet) {
+            if let character = selectedCharacter {
+                CharacterSheetView(character: character)
+            } else {
+                Text("No character selected")
+            }
+        }
         .onChange(of: scenePhase) { phase in
             if phase != .active {
                 viewModel.saveGame()
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {}) {
+                    Image(systemName: "gearshape")
+                }
             }
         }
     }

--- a/CardGame/HeaderView.swift
+++ b/CardGame/HeaderView.swift
@@ -2,30 +2,20 @@ import SwiftUI
 
 struct HeaderView: View {
     let title: String
-    let characters: [Character]
-    @Binding var selectedCharacterID: UUID?
+    // Only display the current room title. The character selector has moved
+    // to the footer toolbar.
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.largeTitle)
-                .bold()
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            CharacterSelectorView(characters: characters,
-                                  selectedCharacterID: $selectedCharacterID)
-        }
-        .padding(.horizontal)
-        .padding(.bottom)
+        Text(title)
+            .font(.largeTitle)
+            .bold()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding([.horizontal, .bottom])
     }
 }
 
 struct HeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        HeaderView(
-            title: "Preview Location",
-            characters: GameViewModel().gameState.party,
-            selectedCharacterID: .constant(nil)
-        )
+        HeaderView(title: "Preview Location")
     }
 }


### PR DESCRIPTION
## Summary
- simplify `HeaderView` to only show the room title
- restructure `ContentView` so interactables and exits are under the header
- move character picker to a footer with a button for a slide‑up sheet
- make the character sheet appear as a bottom drawer
- hide the NavigationStack back button and show a placeholder settings icon

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project CardGame.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1df3fb30832bab34eb833b2f5f97