### PR TITLE
Improve party split UI

### DIFF
--- a/CardGame/CharacterSelectorView.swift
+++ b/CardGame/CharacterSelectorView.swift
@@ -3,17 +3,36 @@ import SwiftUI
 struct CharacterSelectorView: View {
     let characters: [Character]
     @Binding var selectedCharacterID: UUID?
+    var movementMode: PartyMovementMode
 
     var body: some View {
         VStack(alignment: .leading) {
             Text("Choose a Character")
                 .font(.headline)
-            Picker("Select Character", selection: $selectedCharacterID) {
-                ForEach(characters) { character in
-                    Text(character.name).tag(character.id as UUID?)
+
+            if movementMode == .grouped {
+                Picker("Select Character", selection: $selectedCharacterID) {
+                    ForEach(characters) { character in
+                        Text(character.name).tag(character.id as UUID?)
+                    }
+                }
+                .pickerStyle(.segmented)
+            } else {
+                HStack(spacing: 12) {
+                    ForEach(characters) { character in
+                        Button {
+                            selectedCharacterID = character.id
+                        } label: {
+                            Text(character.name)
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 12)
+                                .background(selectedCharacterID == character.id ? Color.accentColor.opacity(0.2) : Color.clear)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
-            .pickerStyle(.segmented)
         }
     }
 }
@@ -23,6 +42,6 @@ struct CharacterSelectorView_Previews: PreviewProvider {
         CharacterSelectorView(characters: [
             Character(id: UUID(), name: "Indy", characterClass: "Archaeologist", stress: 0, harm: HarmState(), actions: ["Study": 3]),
             Character(id: UUID(), name: "Sallah", characterClass: "Brawler", stress: 0, harm: HarmState(), actions: ["Wreck": 2])
-        ], selectedCharacterID: .constant(nil))
+        ], selectedCharacterID: .constant(nil), movementMode: .grouped)
     }
 }

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -107,7 +107,8 @@ struct ContentView: View {
 
                     HStack {
                         CharacterSelectorView(characters: viewModel.gameState.party,
-                                              selectedCharacterID: $selectedCharacterID)
+                                              selectedCharacterID: $selectedCharacterID,
+                                              movementMode: viewModel.partyMovementMode)
 
                         Button {
                             withAnimation {
@@ -125,10 +126,12 @@ struct ContentView: View {
                         Button {
                             viewModel.toggleMovementMode()
                         } label: {
-                            Text("Movement: \(viewModel.partyMovementMode == .grouped ? "Grouped" : "Solo")")
+                            Text(viewModel.partyMovementMode == .grouped ? "Split Up" : "Stick Together")
                         }
                         .padding()
                         .background(.thinMaterial, in: Capsule())
+                        .disabled(viewModel.partyMovementMode == .solo && !viewModel.canRegroup())
+                        .opacity(viewModel.partyMovementMode == .solo && !viewModel.canRegroup() ? 0.6 : 1)
 
                         Spacer()
 

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -631,8 +631,19 @@ class GameViewModel: ObservableObject {
         return unique.count > 1
     }
 
+    /// Whether all party members currently share the same node.
+    func canRegroup() -> Bool {
+        !isPartyActuallySplit()
+    }
+
     func toggleMovementMode() {
-        partyMovementMode = (partyMovementMode == .grouped) ? .solo : .grouped
+        if partyMovementMode == .grouped {
+            partyMovementMode = .solo
+        } else {
+            if canRegroup() {
+                partyMovementMode = .grouped
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show slider character picker when grouped, split buttons when solo
- disable regroup button if characters aren't together
- allow ViewModel to prevent regrouping unless everyone is in the same node

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683f276991c8832bac1f21b363da9846