### PR TITLE
Implement Harm boon support

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -106,15 +106,24 @@ class GameViewModel: ObservableObject {
             if let penalty = HarmLibrary.families[harm.familyId]?.lesser.penalty {
                 apply(penalty: penalty, description: harm.description, to: action.actionType, diceCount: &diceCount, effect: &effect, notes: &notes)
             }
+            if let boon = HarmLibrary.families[harm.familyId]?.lesser.boon {
+                apply(boon: boon, description: harm.description, to: action.actionType, diceCount: &diceCount, position: &position, effect: &effect, notes: &notes)
+            }
         }
         for harm in character.harm.moderate {
             if let penalty = HarmLibrary.families[harm.familyId]?.moderate.penalty {
                 apply(penalty: penalty, description: harm.description, to: action.actionType, diceCount: &diceCount, effect: &effect, notes: &notes)
             }
+            if let boon = HarmLibrary.families[harm.familyId]?.moderate.boon {
+                apply(boon: boon, description: harm.description, to: action.actionType, diceCount: &diceCount, position: &position, effect: &effect, notes: &notes)
+            }
         }
         for harm in character.harm.severe {
             if let penalty = HarmLibrary.families[harm.familyId]?.severe.penalty {
                 apply(penalty: penalty, description: harm.description, to: action.actionType, diceCount: &diceCount, effect: &effect, notes: &notes)
+            }
+            if let boon = HarmLibrary.families[harm.familyId]?.severe.boon {
+                apply(boon: boon, description: harm.description, to: action.actionType, diceCount: &diceCount, position: &position, effect: &effect, notes: &notes)
             }
         }
         // Apply bonuses from modifiers
@@ -554,6 +563,25 @@ class GameViewModel: ObservableObject {
             notes.append("(Cannot perform due to \(description))")
         default:
             break
+        }
+    }
+
+    private func apply(boon: Modifier, description: String, to actionType: String, diceCount: inout Int, position: inout RollPosition, effect: inout RollEffect, notes: inout [String]) {
+        if let specific = boon.applicableToAction, specific != actionType { return }
+
+        if boon.bonusDice != 0 {
+            diceCount += boon.bonusDice
+            notes.append("(+\(boon.bonusDice)d from \(description))")
+        }
+
+        if boon.improvePosition {
+            position = position.improved()
+            notes.append("(Improved Position from \(description))")
+        }
+
+        if boon.improveEffect {
+            effect = effect.increased()
+            notes.append("(+1 Effect from \(description))")
         }
     }
 

--- a/CardGame/HarmTooltipView.swift
+++ b/CardGame/HarmTooltipView.swift
@@ -26,6 +26,16 @@ struct HarmTooltipView: View {
         }
     }
 
+    private func boonDescription(_ boon: Modifier) -> String {
+        var parts: [String] = []
+        if boon.bonusDice != 0 { parts.append("+\(boon.bonusDice)d") }
+        if boon.improvePosition { parts.append("Improved Position") }
+        if boon.improveEffect { parts.append("+1 Effect") }
+        let detail = parts.joined(separator: ", ")
+        if detail.isEmpty { return boon.description }
+        return "\(detail) - \(boon.description)"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let tier = tier {
@@ -35,6 +45,11 @@ struct HarmTooltipView: View {
                     Text(penaltyDescription(penalty))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
+                }
+                if let boon = tier.boon {
+                    Text(boonDescription(boon))
+                        .font(.subheadline)
+                        .foregroundColor(.green)
                 }
             } else {
                 Text("Unknown Harm")

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -128,6 +128,31 @@ struct Character: Identifiable, Codable {
 struct HarmTier: Codable {
     var description: String
     var penalty: Penalty? // Penalty is optional for the "Fatal" tier
+    var boon: Modifier? // Optional boon granted while this harm is active
+
+    enum CodingKeys: String, CodingKey {
+        case description, penalty, boon
+    }
+
+    init(description: String, penalty: Penalty? = nil, boon: Modifier? = nil) {
+        self.description = description
+        self.penalty = penalty
+        self.boon = boon
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        description = try container.decode(String.self, forKey: .description)
+        penalty = try container.decodeIfPresent(Penalty.self, forKey: .penalty)
+        boon = try container.decodeIfPresent(Modifier.self, forKey: .boon)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(description, forKey: .description)
+        try container.encodeIfPresent(penalty, forKey: .penalty)
+        try container.encodeIfPresent(boon, forKey: .boon)
+    }
 }
 
 /// Defines a full "family" of related harms, from minor to fatal.

--- a/Content/Scenarios/charons_bargain/harm_families.json
+++ b/Content/Scenarios/charons_bargain/harm_families.json
@@ -1,0 +1,42 @@
+{
+  "families": [
+    {
+      "id": "vfe_physical_aberration",
+      "lesser": {
+        "description": "Warped Flesh",
+        "penalty": { "type": "actionPenalty", "actionType": "Command" },
+        "boon": { "improveEffect": true, "description": "VFE Mutation Surge" }
+      },
+      "moderate": {
+        "description": "Mutated Limbs",
+        "penalty": { "type": "reduceEffect" },
+        "boon": { "bonusDice": 1, "description": "Unnatural Strength" }
+      },
+      "severe": {
+        "description": "Grotesque Form",
+        "penalty": { "type": "banAction", "actionType": "Charm" },
+        "boon": { "bonusDice": 2, "description": "Feral Fury" }
+      },
+      "fatal": { "description": "Runaway Mutation" }
+    },
+    {
+      "id": "vfe_cerebral_euphoria",
+      "lesser": {
+        "description": "Strange Euphoria",
+        "penalty": { "type": "increaseStressCost", "amount": 1 },
+        "boon": { "bonusDice": 1, "description": "Heightened Focus" }
+      },
+      "moderate": {
+        "description": "Mental Expansion",
+        "penalty": { "type": "actionPenalty", "actionType": "Hack" },
+        "boon": { "improvePosition": true, "description": "Mental Clarity" }
+      },
+      "severe": {
+        "description": "Psychic Overload",
+        "penalty": { "type": "banAction", "actionType": "Study" },
+        "boon": { "improveEffect": true, "description": "Psychic Insight" }
+      },
+      "fatal": { "description": "Mind Shatter" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- expand HarmTier with optional `boon` modifier
- apply harm boons in `GameViewModel.calculateProjection`
- show harm boons in `HarmTooltipView`
- add Charon's Bargain harm families demonstrating double-edged effects

## Testing
- `xcodebuild` not available in container; unable to run iOS tests

------
https://chatgpt.com/codex/tasks/task_e_683f69986858832bac8701a4ecf7d34d