### PR TITLE
Implement map loading infrastructure

### DIFF
--- a/CardGame/ContentLoader.swift
+++ b/CardGame/ContentLoader.swift
@@ -6,6 +6,8 @@ struct ScenarioManifest: Codable, Identifiable, Hashable {
     var title: String
     var description: String
     var entryNode: String?
+    /// Name of a JSON file defining a fixed map for this scenario.
+    var mapFile: String?
 }
 
 class ContentLoader {
@@ -98,6 +100,21 @@ class ContentLoader {
         } catch {
             print("Failed to decode \(filename): \(error)")
             return []
+        }
+    }
+
+    /// Load a predefined DungeonMap from the given file name within this scenario.
+    func loadMap(named file: String) -> DungeonMap? {
+        guard let url = Self.url(for: file, scenario: scenarioName) else {
+            print("Failed to locate map file \(file) for scenario \(scenarioName)")
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(DungeonMap.self, from: data)
+        } catch {
+            print("Failed to decode map file \(file): \(error)")
+            return nil
         }
     }
 }

--- a/CardGame/DungeonGenerator.swift
+++ b/CardGame/DungeonGenerator.swift
@@ -13,7 +13,18 @@ class DungeonGenerator {
         self.content = content
     }
 
-    func generate(level: Int) -> (DungeonMap, [GameClock]) {
+    func generate(level: Int, manifest: ScenarioManifest? = nil) -> (DungeonMap, [GameClock]) {
+        let manifestToUse = manifest ?? content.scenarioManifest
+        if let manifest = manifestToUse,
+           let mapFile = manifest.mapFile,
+           let predefined = content.loadMap(named: mapFile) {
+            let clockCount = Int.random(in: 1...2)
+            let clocks = Array(clockTemplates.shuffled().prefix(clockCount))
+            return (predefined, clocks)
+        } else if let manifest = manifestToUse, manifest.mapFile != nil {
+            print("Warning: Failed to load map file \(manifest.mapFile!) for scenario \(manifest.id)")
+        }
+
         var nodes: [String: MapNode] = [:]
         let nodeCount = 5 + level // Simple scaling
 

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -675,7 +675,8 @@ class GameViewModel: ObservableObject {
         // selected scenario.
         ContentLoader.shared = ContentLoader(scenario: scenario)
         let generator = DungeonGenerator(content: ContentLoader.shared)
-        let (newDungeon, generatedClocks) = generator.generate(level: 1)
+        let manifest = ContentLoader.shared.scenarioManifest
+        let (newDungeon, generatedClocks) = generator.generate(level: 1, manifest: manifest)
 
         self.gameState = GameState(
             scenarioName: scenario,

--- a/Content/Scenarios/charons_bargain/map_charons_bargain.json
+++ b/Content/Scenarios/charons_bargain/map_charons_bargain.json
@@ -1,0 +1,29 @@
+{
+  "startingNodeID": "00000000-0000-0000-0000-000000000001",
+  "nodes": {
+    "00000000-0000-0000-0000-000000000001": {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "Docking Bay",
+      "soundProfile": "metal_echoes",
+      "interactables": [],
+      "connections": [
+        {
+          "toNodeID": "00000000-0000-0000-0000-000000000002",
+          "description": "Proceed to Main Corridor",
+          "isUnlocked": true
+        }
+      ],
+      "theme": "industrial_docking",
+      "isDiscovered": true
+    },
+    "00000000-0000-0000-0000-000000000002": {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "name": "Main Corridor",
+      "soundProfile": "metal_echoes",
+      "interactables": [],
+      "connections": [],
+      "theme": "industrial_corridor",
+      "isDiscovered": false
+    }
+  }
+}

--- a/Content/Scenarios/charons_bargain/scenario.json
+++ b/Content/Scenarios/charons_bargain/scenario.json
@@ -1,0 +1,6 @@
+{
+  "id": "charons_bargain",
+  "title": "Charon's Bargain",
+  "description": "A desperate mission aboard the Charon.",
+  "mapFile": "map_charons_bargain.json"
+}


### PR DESCRIPTION
## Summary
- enable scenario manifests to specify a map file
- load dungeon maps from JSON via `ContentLoader`
- make `DungeonGenerator` use a predefined map when available
- pass the scenario manifest when starting a new run
- add placeholder Charon's Bargain scenario files

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683f6ec03118832b8183f938f30fc6b1