### PR TITLE
Fix map connection rendering

### DIFF
--- a/CardGame/NodeConnectionsView.swift
+++ b/CardGame/NodeConnectionsView.swift
@@ -9,7 +9,7 @@ struct NodeConnectionsView: View {
             Text("Paths from this room")
                 .font(.headline)
             if let node = currentNode {
-                ForEach(node.connections, id: \.toNodeID) { connection in
+                ForEach(Array(node.connections.enumerated()), id: \.0) { _, connection in
                     Button {
                         onMove(connection)
                     } label: {


### PR DESCRIPTION
## Summary
- ensure connections use unique IDs when drawn
- update NodeConnectionsView ForEach to avoid ID collisions

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project CardGame.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f984dc0832ba8e94b2fcd6bc9c1