### PR TITLE
Fix toolbar button layout

### DIFF
--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -139,10 +139,12 @@ struct ContentView: View {
                             showingStatusSheet.toggle()
                         } label: {
                             Image(systemName: "person.3.fill")
-                            Text("Party")
+                            Text("Status")
                         }
                         .padding()
                         .background(.thinMaterial, in: Capsule())
+
+                        Spacer()
 
                         Button {
                             showingMap.toggle()


### PR DESCRIPTION
## Summary
- evenly space toolbar buttons
- rename "Party" button to "Status"

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8259bdc8832b80c976d8e0f59371