### PR TITLE
Add optional modifier content and tests

### DIFF
--- a/CardGameTests/ModifierSystemTests.swift
+++ b/CardGameTests/ModifierSystemTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import CardGame
+
+final class ModifierSystemTests: XCTestCase {
+    func makeTestCharacter() -> Character {
+        Character(id: UUID(),
+                  name: "Tester",
+                  characterClass: "Rogue",
+                  stress: 0,
+                  harm: HarmState(),
+                  actions: ["Skirmish": 2],
+                  treasures: [],
+                  modifiers: [])
+    }
+
+    func makeTestAction() -> ActionOption {
+        ActionOption(name: "Strike",
+                     actionType: "Skirmish",
+                     position: .risky,
+                     effect: .standard)
+    }
+
+    func testRollContextIncludesOptionalModsAndPush() throws {
+        ContentLoader.shared = ContentLoader()
+        var character = makeTestCharacter()
+        let optional = Modifier(bonusDice: 1, uses: 1, isOptionalToApply: true, description: "Lucky Charm")
+        let alwaysOn = Modifier(bonusDice: 1, uses: 1, isOptionalToApply: false, description: "Battle Fury")
+        character.modifiers = [optional, alwaysOn]
+
+        let viewModel = GameViewModel()
+        let context = viewModel.getRollContext(for: makeTestAction(), with: character)
+
+        XCTAssertEqual(context.baseProjection.finalDiceCount, 3)
+        XCTAssertEqual(context.optionalModifiers.count, 2)
+        let descriptions = context.optionalModifiers.map { $0.description }
+        XCTAssertTrue(descriptions.contains("Lucky Charm"))
+        XCTAssertTrue(descriptions.contains("Push Yourself"))
+    }
+
+    func testCalculateEffectiveProjection() throws {
+        let vm = GameViewModel()
+        let base = RollProjectionDetails(baseDiceCount: 2,
+                                         finalDiceCount: 2,
+                                         basePosition: .risky,
+                                         finalPosition: .risky,
+                                         baseEffect: .standard,
+                                         finalEffect: .standard,
+                                         notes: [])
+        let mod = Modifier(bonusDice: 2, uses: 1, isOptionalToApply: true, description: "Elixir")
+        let result = vm.calculateEffectiveProjection(baseProjection: base, applying: [mod])
+        XCTAssertEqual(result.finalDiceCount, 4)
+    }
+
+    func testPerformActionConsumesModifier() throws {
+        ContentLoader.shared = ContentLoader()
+        var character = makeTestCharacter()
+        let mod = Modifier(bonusDice: 1, uses: 1, isOptionalToApply: true, description: "Charm")
+        character.modifiers = [mod]
+        let vm = GameViewModel()
+        vm.gameState.party = [character]
+        vm.gameState.characterLocations[character.id.uuidString] = UUID()
+
+        _ = vm.performAction(for: makeTestAction(),
+                             with: character,
+                             interactableID: nil,
+                             usingDice: [6,6,6],
+                             chosenOptionalModifierIDs: [mod.id])
+
+        XCTAssertTrue(vm.gameState.party[0].modifiers.isEmpty)
+    }
+}

--- a/Content/Scenarios/charons_bargain/harm_families.json
+++ b/Content/Scenarios/charons_bargain/harm_families.json
@@ -5,17 +5,17 @@
       "lesser": {
         "description": "Warped Flesh",
         "penalty": { "type": "actionPenalty", "actionType": "Command" },
-        "boon": { "improveEffect": true, "description": "VFE Mutation Surge" }
+        "boon": { "improveEffect": true, "description": "VFE Mutation Surge", "isOptionalToApply": false }
       },
       "moderate": {
         "description": "Mutated Limbs",
         "penalty": { "type": "reduceEffect" },
-        "boon": { "bonusDice": 1, "description": "Unnatural Strength" }
+        "boon": { "bonusDice": 1, "description": "Unnatural Strength", "isOptionalToApply": false }
       },
       "severe": {
         "description": "Grotesque Form",
         "penalty": { "type": "banAction", "actionType": "Charm" },
-        "boon": { "bonusDice": 2, "description": "Feral Fury" }
+        "boon": { "bonusDice": 2, "description": "Feral Fury", "isOptionalToApply": false }
       },
       "fatal": { "description": "Runaway Mutation" }
     },
@@ -24,17 +24,17 @@
       "lesser": {
         "description": "Strange Euphoria",
         "penalty": { "type": "increaseStressCost", "amount": 1 },
-        "boon": { "bonusDice": 1, "description": "Heightened Focus" }
+        "boon": { "bonusDice": 1, "description": "Heightened Focus", "isOptionalToApply": false }
       },
       "moderate": {
         "description": "Mental Expansion",
         "penalty": { "type": "actionPenalty", "actionType": "Hack" },
-        "boon": { "improvePosition": true, "description": "Mental Clarity" }
+        "boon": { "improvePosition": true, "description": "Mental Clarity", "isOptionalToApply": false }
       },
       "severe": {
         "description": "Psychic Overload",
         "penalty": { "type": "banAction", "actionType": "Study" },
-        "boon": { "improveEffect": true, "description": "Psychic Insight" }
+        "boon": { "improveEffect": true, "description": "Psychic Insight", "isOptionalToApply": false }
       },
       "fatal": { "description": "Mind Shatter" }
     }

--- a/Content/Scenarios/test_lab/treasures.json
+++ b/Content/Scenarios/test_lab/treasures.json
@@ -5,7 +5,8 @@
     "description": "A fragment of the idol, cleansed of its curse.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "Blessing of the Idol"
+      "description": "Blessing of the Idol",
+      "isOptionalToApply": true
     }
   },
   {
@@ -14,7 +15,8 @@
     "description": "A coin from a forgotten empire.",
     "grantedModifier": {
       "improveEffect": true,
-      "description": "Lucky Find"
+      "description": "Lucky Find",
+      "isOptionalToApply": true
     }
   },
   {
@@ -24,7 +26,8 @@
     "grantedModifier": {
       "improvePosition": true,
       "uses": 1,
-      "description": "from Steadying Herbs"
+      "description": "from Steadying Herbs",
+      "isOptionalToApply": true
     }
   },
   {
@@ -35,7 +38,8 @@
       "bonusDice": 1,
       "applicableToAction": "Tinker",
       "uses": 2,
-      "description": "from Precise Tools"
+      "description": "from Precise Tools",
+      "isOptionalToApply": true
     }
   },
   {
@@ -46,7 +50,8 @@
       "bonusDice": 1,
       "applicableToAction": "Attune",
       "uses": 1,
-      "description": "from Charmed Talisman"
+      "description": "from Charmed Talisman",
+      "isOptionalToApply": true
     }
   },
   {
@@ -56,7 +61,8 @@
     "grantedModifier": {
       "improveEffect": true,
       "uses": 1,
-      "description": "from Map Fragment"
+      "description": "from Map Fragment",
+      "isOptionalToApply": true
     }
   },
   {
@@ -65,7 +71,8 @@
     "description": "An old lantern that glows with an eerie light.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "from Cursed Lantern"
+      "description": "from Cursed Lantern",
+      "isOptionalToApply": true
     },
   "tags": ["Haunted", "Light Source"]
   },
@@ -73,7 +80,32 @@
     "id": "treasure_test_gem",
     "name": "Test Gem",
     "description": "Glows with uncertain power.",
-    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem" },
+    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem", "isOptionalToApply": true },
+    "tags": ["Test"]
+  },
+  {
+    "id": "treasure_minor_blessing",
+    "name": "Minor Blessing",
+    "description": "A fleeting boon from mysterious forces.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "uses": 1,
+      "description": "from Minor Blessing",
+      "isOptionalToApply": true
+    },
+    "tags": ["Test"]
+  },
+  {
+    "id": "treasure_major_blessing",
+    "name": "Major Blessing",
+    "description": "Power surges through this relic.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "improveEffect": true,
+      "uses": 1,
+      "description": "from Major Blessing",
+      "isOptionalToApply": true
+    },
     "tags": ["Test"]
   }
 ]

--- a/Content/Scenarios/tomb/treasures.json
+++ b/Content/Scenarios/tomb/treasures.json
@@ -5,7 +5,8 @@
     "description": "A fragment of the idol, cleansed of its curse.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "Blessing of the Idol"
+      "description": "Blessing of the Idol",
+      "isOptionalToApply": true
     }
   },
   {
@@ -14,7 +15,8 @@
     "description": "A coin from a forgotten empire.",
     "grantedModifier": {
       "improveEffect": true,
-      "description": "Lucky Find"
+      "description": "Lucky Find",
+      "isOptionalToApply": true
     }
   },
   {
@@ -24,7 +26,8 @@
     "grantedModifier": {
       "improvePosition": true,
       "uses": 1,
-      "description": "from Steadying Herbs"
+      "description": "from Steadying Herbs",
+      "isOptionalToApply": true
     }
   },
   {
@@ -35,7 +38,8 @@
       "bonusDice": 1,
       "applicableToAction": "Tinker",
       "uses": 2,
-      "description": "from Precise Tools"
+      "description": "from Precise Tools",
+      "isOptionalToApply": true
     }
   },
   {
@@ -46,7 +50,8 @@
       "bonusDice": 1,
       "applicableToAction": "Attune",
       "uses": 1,
-      "description": "from Charmed Talisman"
+      "description": "from Charmed Talisman",
+      "isOptionalToApply": true
     }
   },
   {
@@ -56,7 +61,8 @@
     "grantedModifier": {
       "improveEffect": true,
       "uses": 1,
-      "description": "from Map Fragment"
+      "description": "from Map Fragment",
+      "isOptionalToApply": true
     }
   },
   {
@@ -65,7 +71,8 @@
     "description": "An old lantern that glows with an eerie light.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "from Cursed Lantern"
+      "description": "from Cursed Lantern",
+      "isOptionalToApply": true
     },
     "tags": ["Haunted", "Light Source"]
   }

--- a/Content/treasures.json
+++ b/Content/treasures.json
@@ -5,7 +5,8 @@
     "description": "A fragment of the idol, cleansed of its curse.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "Blessing of the Idol"
+      "description": "Blessing of the Idol",
+      "isOptionalToApply": true
     }
   },
   {
@@ -14,7 +15,8 @@
     "description": "A coin from a forgotten empire.",
     "grantedModifier": {
       "improveEffect": true,
-      "description": "Lucky Find"
+      "description": "Lucky Find",
+      "isOptionalToApply": true
     }
   },
   {
@@ -24,7 +26,8 @@
     "grantedModifier": {
       "improvePosition": true,
       "uses": 1,
-      "description": "from Steadying Herbs"
+      "description": "from Steadying Herbs",
+      "isOptionalToApply": true
     }
   },
   {
@@ -35,7 +38,8 @@
       "bonusDice": 1,
       "applicableToAction": "Tinker",
       "uses": 2,
-      "description": "from Precise Tools"
+      "description": "from Precise Tools",
+      "isOptionalToApply": true
     }
   },
   {
@@ -46,7 +50,8 @@
       "bonusDice": 1,
       "applicableToAction": "Attune",
       "uses": 1,
-      "description": "from Charmed Talisman"
+      "description": "from Charmed Talisman",
+      "isOptionalToApply": true
     }
   },
   {
@@ -56,7 +61,8 @@
     "grantedModifier": {
       "improveEffect": true,
       "uses": 1,
-      "description": "from Map Fragment"
+      "description": "from Map Fragment",
+      "isOptionalToApply": true
     }
   },
   {
@@ -65,7 +71,8 @@
     "description": "An old lantern that glows with an eerie light.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "from Cursed Lantern"
+      "description": "from Cursed Lantern",
+      "isOptionalToApply": true
     },
     "tags": ["Haunted", "Light Source"]
   },
@@ -75,7 +82,8 @@
     "description": "Opens a locked door somewhere in the tomb.",
     "grantedModifier": {
       "bonusDice": 1,
-      "description": "from Silver Key"
+      "description": "from Silver Key",
+      "isOptionalToApply": true
     },
   "tags": ["Key"]
   },
@@ -83,7 +91,32 @@
     "id": "treasure_test_gem",
     "name": "Test Gem",
     "description": "Glows with uncertain power.",
-    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem" },
+    "grantedModifier": { "bonusDice": 1, "description": "from Test Gem", "isOptionalToApply": true },
+    "tags": ["Test"]
+  },
+  {
+    "id": "treasure_minor_blessing",
+    "name": "Minor Blessing",
+    "description": "A fleeting boon from mysterious forces.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "uses": 1,
+      "description": "from Minor Blessing",
+      "isOptionalToApply": true
+    },
+    "tags": ["Test"]
+  },
+  {
+    "id": "treasure_major_blessing",
+    "name": "Major Blessing",
+    "description": "Power surges through this relic.",
+    "grantedModifier": {
+      "bonusDice": 1,
+      "improveEffect": true,
+      "uses": 1,
+      "description": "from Major Blessing",
+      "isOptionalToApply": true
+    },
     "tags": ["Test"]
   }
 ]


### PR DESCRIPTION
## Summary
- mark granted modifiers as optional in treasure data
- add new optional blessing treasures for testing
- specify harm boon optionality in Charon's Bargain scenario
- add unit tests for roll context, projection calculation, and modifier consumption

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68407bcd1864832b85e8709fe276dbcb