### PR TITLE
Fix push dice with zero rating

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RollProjectionDetails {
     var baseDiceCount: Int
     var finalDiceCount: Int
+    var rawDicePool: Int
     var basePosition: RollPosition
     var finalPosition: RollPosition
     var baseEffect: RollEffect
@@ -178,6 +179,7 @@ class GameViewModel: ObservableObject {
             notes.append("Group Action: party rolls together; best result counts. Leader takes 1 Stress per failed ally.")
         }
 
+        let rawDicePool = diceCount
         diceCount = max(diceCount, 0) // Can't roll negative dice
 
         if baseDice == 0 {
@@ -189,6 +191,7 @@ class GameViewModel: ObservableObject {
         return RollProjectionDetails(
             baseDiceCount: baseDice,
             finalDiceCount: displayDice,
+            rawDicePool: rawDicePool,
             basePosition: basePosition,
             finalPosition: position,
             baseEffect: baseEffect,
@@ -253,6 +256,7 @@ class GameViewModel: ObservableObject {
             }
         }
 
+        let rawDicePool = diceCount
         diceCount = max(diceCount, 0)
         if baseDice == 0 { notes.append("\(character.name) has 0 rating in \(action.actionType): Rolling 2d6, taking lowest.") }
 
@@ -260,6 +264,7 @@ class GameViewModel: ObservableObject {
         let projection = RollProjectionDetails(
             baseDiceCount: baseDice,
             finalDiceCount: displayDice,
+            rawDicePool: rawDicePool,
             basePosition: basePosition,
             finalPosition: position,
             baseEffect: baseEffect,
@@ -308,6 +313,7 @@ class GameViewModel: ObservableObject {
         for mod in chosenModifierStructs {
             if mod.bonusDice != 0 {
                 result.finalDiceCount += mod.bonusDice
+                result.rawDicePool += mod.bonusDice
                 result.notes.append("(+\(mod.bonusDice)d from \(mod.description))")
             }
             if mod.improvePosition {
@@ -393,15 +399,16 @@ class GameViewModel: ObservableObject {
         workingProjection = calculateEffectiveProjection(baseProjection: workingProjection, applying: appliedOptionalMods)
         var finalEffect = workingProjection.finalEffect
         let finalPosition = workingProjection.finalPosition
-        let ratingZero = (character.actions[action.actionType] ?? 0) == 0
-        let dicePool = max(workingProjection.finalDiceCount, ratingZero ? 2 : 1)
+        let rawPool = workingProjection.rawDicePool
+        let useRatingZero = rawPool <= 0
+        let dicePool = useRatingZero ? 2 : rawPool
         var actualDiceRolled: [Int] = []
         var highestRoll: Int
         var isCritical = false
 
         if let provided = diceResults {
             actualDiceRolled = provided
-            if ratingZero {
+            if useRatingZero {
                 if provided.count >= 2 {
                     highestRoll = min(provided[0], provided[1])
                     if provided[0] == 6 && provided[1] == 6 { isCritical = true }
@@ -414,7 +421,7 @@ class GameViewModel: ObservableObject {
                 if sixes > 1 { isCritical = true }
             }
         } else {
-            if ratingZero {
+            if useRatingZero {
                 let d1 = Int.random(in: 1...6)
                 let d2 = Int.random(in: 1...6)
                 actualDiceRolled = [d1, d2]

--- a/CardGameTests/ModifierSystemTests.swift
+++ b/CardGameTests/ModifierSystemTests.swift
@@ -41,6 +41,7 @@ final class ModifierSystemTests: XCTestCase {
         let vm = GameViewModel()
         let base = RollProjectionDetails(baseDiceCount: 2,
                                          finalDiceCount: 2,
+                                         rawDicePool: 2,
                                          basePosition: .risky,
                                          finalPosition: .risky,
                                          baseEffect: .standard,


### PR DESCRIPTION
## Summary
- track raw dice pool in roll projections
- allow bonus dice to cancel the 0-rating penalty
- adjust tests for new RollProjectionDetails parameter

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_68408141e6d8832b9d05297037b3f019