### PR TITLE
Allow run to continue after single fatal harm

### DIFF
--- a/CardGame/CharacterSelectorView.swift
+++ b/CardGame/CharacterSelectorView.swift
@@ -12,14 +12,14 @@ struct CharacterSelectorView: View {
 
             if movementMode == .grouped {
                 Picker("Select Character", selection: $selectedCharacterID) {
-                    ForEach(characters) { character in
+                    ForEach(characters.filter { !$0.isDefeated }) { character in
                         Text(character.name).tag(character.id as UUID?)
                     }
                 }
                 .pickerStyle(.segmented)
             } else {
                 HStack(spacing: 12) {
-                    ForEach(characters) { character in
+                    ForEach(characters.filter { !$0.isDefeated }) { character in
                         Button {
                             selectedCharacterID = character.id
                         } label: {

--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -46,6 +46,12 @@ struct CharacterSheetView: View {
                 Text(character.name)
                     .font(.headline)
                     .bold()
+                if character.isDefeated {
+                    Text("DEFEATED")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.leading, 4)
+                }
                 Spacer()
                 Text(character.characterClass)
                     .font(.subheadline)

--- a/CardGame/ContentView.swift
+++ b/CardGame/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
 
     // Helper to retrieve the selected character object
     private var selectedCharacter: Character? {
-        viewModel.gameState.party.first { $0.id == selectedCharacterID }
+        viewModel.gameState.party.first { $0.id == selectedCharacterID && !$0.isDefeated }
     }
 
     private func performTransition(to connection: NodeConnection) {

--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -515,7 +515,7 @@ class GameViewModel: ObservableObject {
         var bestRoll = 0
         var failures = 0
 
-        for member in gameState.party {
+        for member in gameState.party where !member.isDefeated {
             let dicePool = max(member.actions[action.actionType] ?? 0, 1)
             var highest = 0
             for _ in 0..<dicePool { highest = max(highest, Int.random(in: 1...6)) }
@@ -823,8 +823,16 @@ class GameViewModel: ObservableObject {
                     gameState.party[charIndex].harm.severe.append((familyId, harm.description))
                     return "Suffered SEVERE Harm: \(harm.description)."
                 } else {
-                    gameState.status = .gameOver
+                    // Character suffers Fatal Harm and is removed from play
+                    gameState.party[charIndex].isDefeated = true
+                    gameState.characterLocations.removeValue(forKey: characterId.uuidString)
                     let fatalDescription = harmFamily.fatal.description
+
+                    // If no active characters remain, end the run
+                    if gameState.party.allSatisfy({ $0.isDefeated }) {
+                        gameState.status = .gameOver
+                    }
+
                     saveGame()
                     return "Suffered FATAL Harm: \(fatalDescription)."
                 }
@@ -870,7 +878,7 @@ class GameViewModel: ObservableObject {
 
     /// Check if any party member possesses a treasure with the given tag.
     func partyHasTreasureTag(_ tag: String) -> Bool {
-        for member in gameState.party {
+        for member in gameState.party where !member.isDefeated {
             for treasure in member.treasures {
                 if treasure.tags.contains(tag) { return true }
             }
@@ -886,8 +894,8 @@ class GameViewModel: ObservableObject {
         if partyMovementMode == .solo {
             gameState.characterLocations[characterID.uuidString] = connection.toNodeID
         } else {
-            for id in gameState.party.map({ $0.id }) {
-                gameState.characterLocations[id.uuidString] = connection.toNodeID
+            for member in gameState.party where !member.isDefeated {
+                gameState.characterLocations[member.id.uuidString] = connection.toNodeID
             }
         }
 

--- a/CardGame/MapView.swift
+++ b/CardGame/MapView.swift
@@ -58,6 +58,7 @@ struct MapView: View {
         }
 
         let charactersInNode = viewModel.gameState.party.filter { character in
+            !character.isDefeated &&
             viewModel.gameState.characterLocations[character.id.uuidString] == nodeID
         }.map { $0.name }
 

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -136,6 +136,65 @@ struct Character: Identifiable, Codable {
     var actions: [String: Int] // e.g., ["Study": 2, "Tinker": 1]
     var treasures: [Treasure] = []
     var modifiers: [Modifier] = []
+    /// Whether this character can still act. Characters become defeated after
+    /// suffering Fatal Harm.
+    var isDefeated: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, characterClass, stress, harm, actions, treasures, modifiers, isDefeated
+    }
+
+    init(id: UUID,
+         name: String,
+         characterClass: String,
+         stress: Int,
+         harm: HarmState,
+         actions: [String: Int],
+         treasures: [Treasure] = [],
+         modifiers: [Modifier] = [],
+         isDefeated: Bool = false) {
+        self.id = id
+        self.name = name
+        self.characterClass = characterClass
+        self.stress = stress
+        self.harm = harm
+        self.actions = actions
+        self.treasures = treasures
+        self.modifiers = modifiers
+        self.isDefeated = isDefeated
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        characterClass = try container.decode(String.self, forKey: .characterClass)
+        stress = try container.decode(Int.self, forKey: .stress)
+        harm = try container.decode(HarmState.self, forKey: .harm)
+        actions = try container.decode([String: Int].self, forKey: .actions)
+        treasures = try container.decodeIfPresent([Treasure].self, forKey: .treasures) ?? []
+        modifiers = try container.decodeIfPresent([Modifier].self, forKey: .modifiers) ?? []
+        isDefeated = try container.decodeIfPresent(Bool.self, forKey: .isDefeated) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(characterClass, forKey: .characterClass)
+        try container.encode(stress, forKey: .stress)
+        try container.encode(harm, forKey: .harm)
+        try container.encode(actions, forKey: .actions)
+        if !treasures.isEmpty {
+            try container.encode(treasures, forKey: .treasures)
+        }
+        if !modifiers.isEmpty {
+            try container.encode(modifiers, forKey: .modifiers)
+        }
+        if isDefeated {
+            try container.encode(isDefeated, forKey: .isDefeated)
+        }
+    }
 }
 
 /// Defines a single tier of a harm family.


### PR DESCRIPTION
## Summary
- add `isDefeated` flag to `Character` and custom Codable handling
- mark characters as defeated instead of ending the run when they take fatal harm
- only show active characters in selection and map views
- display defeated status on character sheets
- update movement and treasure checks to ignore defeated characters

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1110c64832b9751bc9b3c9095fd