### PR TITLE
Implement addClock consequence

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -657,6 +657,15 @@ class GameViewModel: ObservableObject {
                         descriptions.append("Something new appears.")
                     }
                 }
+            case .addClock:
+                if let clockToAdd = consequence.newClock {
+                    if !gameState.activeClocks.contains(where: { $0.name == clockToAdd.name }) {
+                        gameState.activeClocks.append(clockToAdd)
+                        if !narrativeUsed {
+                            descriptions.append("A new threat emerges: \(clockToAdd.name).")
+                        }
+                    }
+                }
             case .gainTreasure:
                 if let treasureId = consequence.treasureId,
                    let treasure = ContentLoader.shared.treasureTemplates.first(where: { $0.id == treasureId }),

--- a/CardGame/Models.swift
+++ b/CardGame/Models.swift
@@ -584,6 +584,7 @@ struct Consequence: Codable {
         case createChoice
         case triggerEvent
         case triggerConsequences
+        case addClock
     }
 
     var kind: ConsequenceKind
@@ -598,6 +599,7 @@ struct Consequence: Codable {
     var interactableId: String?
     var inNodeID: UUID?
     var newInteractable: Interactable?
+    var newClock: GameClock?
     var treasureId: String?
     var duration: String?
     var choiceOptions: [ChoiceOption]?
@@ -614,6 +616,7 @@ struct Consequence: Codable {
         case type, amount, level, familyId, clockName
         case fromNodeID, toNodeID, id, inNodeID
         case interactable, treasure, treasureId
+        case newClock
         case duration, options, eventId, consequences
         case conditions, description
     }
@@ -635,6 +638,7 @@ struct Consequence: Codable {
         interactableId = try container.decodeIfPresent(String.self, forKey: .id)
         inNodeID = nil
         newInteractable = nil
+        newClock = nil
         treasureId = nil
         duration = try container.decodeIfPresent(String.self, forKey: .duration)
         choiceOptions = try container.decodeIfPresent([ChoiceOption].self, forKey: .options)
@@ -656,6 +660,8 @@ struct Consequence: Codable {
             }
         } else if resolvedKind == .addInteractableHere {
             newInteractable = try container.decodeIfPresent(Interactable.self, forKey: .interactable)
+        } else if resolvedKind == .addClock {
+            newClock = try container.decodeIfPresent(GameClock.self, forKey: .newClock)
         }
 
         if resolvedKind == .gainTreasure {
@@ -704,6 +710,9 @@ struct Consequence: Codable {
             try container.encode(ConsequenceKind.addInteractable, forKey: .type)
             try container.encode("current", forKey: .inNodeID)
             try container.encodeIfPresent(newInteractable, forKey: .interactable)
+        case .addClock:
+            try container.encode(ConsequenceKind.addClock, forKey: .type)
+            try container.encodeIfPresent(newClock, forKey: .newClock)
         case .gainTreasure:
             try container.encode(ConsequenceKind.gainTreasure, forKey: .type)
             try container.encodeIfPresent(treasureId, forKey: .treasureId)
@@ -820,6 +829,13 @@ extension Consequence {
     static func triggerConsequences(_ consequences: [Consequence]) -> Consequence {
         var c = Consequence(kind: .triggerConsequences)
         c.triggered = consequences
+        return c
+    }
+
+    /// Add a new clock to the active game state.
+    static func addClock(_ clock: GameClock) -> Consequence {
+        var c = Consequence(kind: .addClock)
+        c.newClock = clock
         return c
     }
 }

--- a/Content/Scenarios/charons_bargain/map_charons_bargain.json
+++ b/Content/Scenarios/charons_bargain/map_charons_bargain.json
@@ -144,8 +144,24 @@
                 {"type": "triggerEvent", "eventId": "cb_beacon_partially_active"}
               ],
               "failure": [
-                { "type": "sufferHarm", "level": "moderate", "familyId": "electric_shock" },
-                { "type": "tickClock", "clockName": "Ship Systems Failing", "amount": 1 }
+                {
+                  "type": "sufferHarm",
+                  "level": "lesser",
+                  "familyId": "electric_shock"
+                },
+                {
+                  "type": "addClock",
+                  "description": "Your clumsy bypass attempt sends an alert to the ship's security AI. A new directive appears on your HUD: QUARANTINE PROTOCOL ENGAGED.",
+                  "newClock": {
+                    "name": "Ship Security Lockdown",
+                    "segments": 4,
+                    "progress": 1,
+                    "onCompleteConsequences": [
+                      { "type": "removeInteractable", "id": "cb_ferryman_shuttle_ready" },
+                      { "type": "addInteractable", "inNodeID": "00000000-0000-0000-0000-000000000001", "interactable": { "$ref": "cb_ferryman_shuttle_locked" } }
+                    ]
+                  }
+                }
               ]
             }
           }


### PR DESCRIPTION
## Summary
- support dynamic clocks via new `addClock` consequence type
- process `.addClock` consequences to update active clocks
- example: `Attempt Quick Repair` in Charon's Bargain adds *Ship Security Lockdown* clock on failure

## Testing
- `xcodebuild -scheme CardGame -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684343b0a550832b96e1ff1b522bdc99