### PR TITLE
Fix Charon's Bargain map JSON

### DIFF
--- a/Content/Scenarios/charons_bargain/clocks.json
+++ b/Content/Scenarios/charons_bargain/clocks.json
@@ -23,7 +23,34 @@
     "segments": 6,
     "progress": 0,
     "onCompleteConsequences": [
-      { "type": "addInteractable", "inNodeID": "00000000-0000-0000-0000-000000000002", "interactable": { "$ref": "threat_crawling_biomass" } }
+      { "type": "addInteractable", "inNodeID": "00000000-0000-0000-0000-000000000002", "interactable": {
+          "id": "threat_crawling_biomass",
+          "title": "Crawling Biomass",
+          "description": "A mass of corrupted tissue creeps across the floor, hungrily reaching for you.",
+          "isThreat": true,
+          "availableActions": [
+            {
+              "name": "Incinerate",
+              "actionType": "Wreck",
+              "position": "risky",
+              "effect": "standard",
+              "outcomes": {
+                "success": [ { "type": "removeSelfInteractable" } ],
+                "failure": [ { "type": "sufferHarm", "level": "moderate", "familyId": "vfe_physical_aberration" } ]
+              }
+            },
+            {
+              "name": "Retreat",
+              "actionType": "Finesse",
+              "position": "desperate",
+              "effect": "limited",
+              "outcomes": {
+                "success": [ { "type": "removeSelfInteractable" } ],
+                "failure": [ { "type": "gainStress", "amount": 1 } ]
+              }
+            }
+          ]
+        } }
     ]
   },
   {

--- a/Content/Scenarios/charons_bargain/map_charons_bargain.json
+++ b/Content/Scenarios/charons_bargain/map_charons_bargain.json
@@ -125,7 +125,7 @@
                   "outcomes": {
                       "success": [
                           { "type": "triggerEvent", "eventId": "cb_beacon_partially_active" },
-                          { "description": "You stabilize the beacon's power supply. It now broadcasts a steady, repeating 'All Clear' signal... which you know is a lie." }
+                          { "type": "triggerConsequences", "description": "You stabilize the beacon's power supply. It now broadcasts a steady, repeating 'All Clear' signal... which you know is a lie.", "consequences": [] }
                       ],
                       "failure": [
                           { "type": "sufferHarm", "level": "lesser", "familyId": "electric_shock" },


### PR DESCRIPTION
## Summary
- fix JSON format in `map_charons_bargain.json` so every consequence has a `type`
- expand clock consequence interactable in `clocks.json` instead of using unsupported `$ref`

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684355c14c64832b98bc695cf35a1bf7