### PR TITLE
Adjust status pane ordering

### DIFF
--- a/CardGame/PartyStatusView.swift
+++ b/CardGame/PartyStatusView.swift
@@ -5,7 +5,7 @@ struct PartyStatusView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Party Status")
+            Text("Status")
                 .font(.headline)
 
             ForEach(viewModel.gameState.party) { character in

--- a/CardGame/StatusSheetView.swift
+++ b/CardGame/StatusSheetView.swift
@@ -6,9 +6,9 @@ struct StatusSheetView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                PartyStatusView(viewModel: viewModel)
-                Divider()
                 ClocksView(viewModel: viewModel)
+                Divider()
+                PartyStatusView(viewModel: viewModel)
                 Spacer()
             }
             .padding()


### PR DESCRIPTION
## Summary
- rename the `PartyStatusView` header to just "Status"
- show `ClocksView` at the top of `StatusSheetView`

## Testing
- `xcodebuild test -project CardGame.xcodeproj -scheme CardGame -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435929e1e8832b979457640bcb582d