### PR TITLE
Fix truncated text and make outcomes scrollable

### DIFF
--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -94,6 +94,7 @@ struct CharacterSheetView: View {
                                 } label: {
                                     VStack {
                                         Text(harm.description)
+                                            .fixedSize(horizontal: false, vertical: true)
                                         if let tier = tier(for: harm.familyId, level: .lesser) {
                                             if let penalty = tier.penalty {
                                                 Text(shortPenaltyDescription(penalty))
@@ -135,6 +136,7 @@ struct CharacterSheetView: View {
                                 } label: {
                                     VStack {
                                         Text(harm.description)
+                                            .fixedSize(horizontal: false, vertical: true)
                                         if let tier = tier(for: harm.familyId, level: .moderate) {
                                             if let penalty = tier.penalty {
                                                 Text(shortPenaltyDescription(penalty))
@@ -173,6 +175,7 @@ struct CharacterSheetView: View {
                         } label: {
                             VStack {
                                 Text(harm.description)
+                                    .fixedSize(horizontal: false, vertical: true)
                                 if let tier = tier(for: harm.familyId, level: .severe) {
                                     if let penalty = tier.penalty {
                                         Text(shortPenaltyDescription(penalty))

--- a/CardGame/DiceRollView.swift
+++ b/CardGame/DiceRollView.swift
@@ -111,7 +111,14 @@ struct DiceRollView: View {
                             .font(.subheadline)
                     }
                     Text("Rolled a \(result.highestRoll)").font(.title3)
-                    Text(result.consequences).padding()
+                    ScrollView {
+                        Text(result.consequences)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .multilineTextAlignment(.leading)
+                            .padding()
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxHeight: 200)
                 }
             } else if let proj = displayedProjection {
                 VStack(spacing: 4) {

--- a/CardGame/HarmTooltipView.swift
+++ b/CardGame/HarmTooltipView.swift
@@ -41,15 +41,18 @@ struct HarmTooltipView: View {
             if let tier = tier {
                 Text(tier.description)
                     .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
                 if let penalty = tier.penalty {
                     Text(penaltyDescription(penalty))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 if let boon = tier.boon {
                     Text(boonDescription(boon))
                         .font(.subheadline)
                         .foregroundColor(.green)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             } else {
                 Text("Unknown Harm")

--- a/CardGame/InteractableCardView.swift
+++ b/CardGame/InteractableCardView.swift
@@ -52,6 +52,7 @@ struct InteractableCardView: View {
                 .font(.title2).bold()
             Text(interactable.description)
                 .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
             if !interactable.tags.isEmpty {
                 HStack(spacing: 4) {
                     ForEach(interactable.tags, id: \.self) { tag in

--- a/CardGame/MainMenuView.swift
+++ b/CardGame/MainMenuView.swift
@@ -68,7 +68,9 @@ private struct ScenarioSelectView: View {
             List(available, id: \.id) { scenario in
                 VStack(alignment: .leading) {
                     Text(scenario.title).font(.headline)
-                    Text(scenario.description).font(.subheadline)
+                    Text(scenario.description)
+                        .font(.subheadline)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .onTapGesture {
                     onSelect(scenario)

--- a/CardGame/NodeConnectionsView.swift
+++ b/CardGame/NodeConnectionsView.swift
@@ -15,6 +15,7 @@ struct NodeConnectionsView: View {
                     } label: {
                         HStack {
                             Text(connection.description)
+                                .fixedSize(horizontal: false, vertical: true)
                             Spacer()
                             if !connection.isUnlocked {
                                 Image(systemName: "lock.fill")

--- a/CardGame/TreasureTooltipView.swift
+++ b/CardGame/TreasureTooltipView.swift
@@ -9,9 +9,11 @@ struct TreasureTooltipView: View {
                 .font(.headline)
             Text(treasure.description)
                 .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
             Text(treasure.grantedModifier.description)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             if !treasure.tags.isEmpty {
                 HStack(spacing: 4) {
                     ForEach(treasure.tags, id: \.self) { tag in


### PR DESCRIPTION
## Summary
- allow consequence text to scroll and give it more room
- prevent truncation on interactable, menu, connection and tooltip text
- wrap harm descriptions so long text displays fully

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f26eb660832b9d2297d9cd45e52c