### PR TITLE
Implement addAction consequence

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -684,6 +684,18 @@ class GameViewModel: ObservableObject {
                         }
                     }
                 }
+            case .addAction:
+                if let nodeID = gameState.characterLocations[partyMemberId.uuidString],
+                   let action = consequence.newAction {
+                    let targetId = consequence.interactableId ?? interactableID
+                    if let tid = targetId,
+                       let idx = gameState.dungeon?.nodes[nodeID.uuidString]?.interactables.firstIndex(where: { $0.id == tid }) {
+                        gameState.dungeon?.nodes[nodeID.uuidString]?.interactables[idx].availableActions.append(action)
+                        if !narrativeUsed {
+                            descriptions.append("'\(action.name)' is now available.")
+                        }
+                    }
+                }
             case .addInteractable:
                 if let inNodeID = consequence.inNodeID, let interactable = consequence.newInteractable {
                     gameState.dungeon?.nodes[inNodeID.uuidString]?.interactables.append(interactable)

--- a/ContentDesign/ContentSchemas.md
+++ b/ContentDesign/ContentSchemas.md
@@ -24,6 +24,10 @@ This document describes key fields used in the JSON content files.
 ```json
 { "type": "removeAction", "id": "self", "actionName": "Open" }
 ```
+`addAction` performs the inverse, adding a new action option to the referenced interactable:
+```json
+{ "type": "addAction", "id": "self", "action": { "name": "Open", "actionType": "Skirmish", "position": "risky", "effect": "standard" } }
+```
 
 ## Treasure
 


### PR DESCRIPTION
## Summary
- support adding new actions to an interactable
- update consequence enum and decoding/encoding
- implement addAction handling in GameViewModel
- add convenience initializer for addAction
- document addAction in content schemas
- test adding an action

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68473924ebec832b8b013ab983bfd009