### PR TITLE
Fix treasure-based action modifiers

### DIFF
--- a/CardGame/GameViewModel.swift
+++ b/CardGame/GameViewModel.swift
@@ -241,8 +241,11 @@ class GameViewModel: ObservableObject {
             }
         }
 
-        // Always-on modifiers
-        for modifier in character.modifiers {
+        // Always-on modifiers (include treasure modifiers just in case)
+        let treasureMods = character.treasures.map { $0.grantedModifier }
+        var modDict: [UUID: Modifier] = [:]
+        for m in (character.modifiers + treasureMods) { modDict[m.id] = m }
+        for modifier in modDict.values {
             if modifier.uses == 0 { continue }
             if modifier.isOptionalToApply { continue }
             if let actions = modifier.applicableActions {
@@ -284,7 +287,10 @@ class GameViewModel: ObservableObject {
 
         // Gather optional modifiers
         var optionalInfos: [SelectableModifierInfo] = []
-        for mod in character.modifiers {
+        let treasureMods2 = character.treasures.map { $0.grantedModifier }
+        var modDict2: [UUID: Modifier] = [:]
+        for m in (character.modifiers + treasureMods2) { modDict2[m.id] = m }
+        for mod in modDict2.values {
             if !mod.isOptionalToApply { continue }
             if mod.uses == 0 { continue }
             if let actions = mod.applicableActions {

--- a/CardGameTests/ModifierSystemTests.swift
+++ b/CardGameTests/ModifierSystemTests.swift
@@ -147,4 +147,18 @@ final class ModifierSystemTests: XCTestCase {
         let tagProj = vm.calculateProjection(for: action, with: character, interactableTags: ["Flora"])
         XCTAssertEqual(tagProj.finalDiceCount, 1)
     }
+
+    func testTreasureModifierForSpecificAction() throws {
+        let vm = GameViewModel()
+        var character = makeTestCharacter()
+        let mod = Modifier(bonusDice: 1, applicableToAction: "Tinker", uses: 1, isOptionalToApply: true, description: "Scrap Parts")
+        let treasure = Treasure(id: "test_scrap", name: "Scrap", description: "", grantedModifier: mod)
+        character.treasures = [treasure]
+        character.actions["Tinker"] = 1
+
+        let action = ActionOption(name: "Repair", actionType: "Tinker", position: .risky, effect: .standard)
+        let context = vm.getRollContext(for: action, with: character)
+
+        XCTAssertTrue(context.optionalModifiers.contains { $0.description == "Scrap Parts" })
+    }
 }


### PR DESCRIPTION
## Summary
- ensure modifier effects from treasures are considered when calculating roll projections
- deduplicate modifiers from treasures and characters
- test that treasure modifiers for a specific action appear as options

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68474bdc8388832bafd5d7f38ae94862