### PR TITLE
Add emoji icons for action ratings

### DIFF
--- a/CardGame/ActionEmoji.swift
+++ b/CardGame/ActionEmoji.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum ActionEmoji {
+    static let mapping: [String: String] = [
+        "Study": "🔍",
+        "Survey": "👁️",
+        "Hunt": "🎯",
+        "Tinker": "🛠️",
+        "Finesse": "🧤",
+        "Prowl": "👣",
+        "Skirmish": "⚔️",
+        "Wreck": "💣",
+        "Attune": "🔮",
+        "Command": "🗣️",
+        "Consort": "🥂",
+        "Sway": "🎻"
+    ]
+
+    static func emoji(for actionType: String) -> String {
+        mapping[actionType] ?? "❓"
+    }
+}

--- a/CardGame/CharacterSheetView.swift
+++ b/CardGame/CharacterSheetView.swift
@@ -222,13 +222,8 @@ struct CharacterSheetView: View {
                         HStack(spacing: 4) {
                             Text(action)
                                 .font(.caption)
-                            HStack(spacing: 1) {
-                                ForEach(0..<rating, id: \.self) { _ in
-                                    Image("icon_stress_pip_lit")
-                                        .resizable()
-                                        .frame(width: 10, height: 10)
-                                }
-                            }
+                            Text(String(repeating: ActionEmoji.emoji(for: action), count: rating))
+                                .font(.caption)
                             Spacer()
                         }
                     }

--- a/CardGame/InteractableCardView.swift
+++ b/CardGame/InteractableCardView.swift
@@ -103,8 +103,9 @@ struct InteractableCardView: View {
             }
             Divider()
             ForEach(interactable.availableActions, id: \.name) { action in
-                let title = action.requiresTest ? action.name : "\(action.name) (Auto)"
-                Button(title) {
+                let displayName = action.requiresTest ? action.name : "\(action.name) (Auto)"
+                let emoji = ActionEmoji.emoji(for: action.actionType)
+                Button("\(emoji) \(displayName)") {
                     onActionTapped(action)
                 }
                 .buttonStyle(.bordered)


### PR DESCRIPTION
## Summary
- provide `ActionEmoji` utility to map action names to emoji
- use emoji to represent action ratings in `CharacterSheetView`
- prepend emoji to interactable action buttons for quick reference

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68486858b904832bb123f27098aaa9b4