### PR TITLE
Fix consequence removal and add debugging

### DIFF
--- a/CardGameTests/CardGameTests.swift
+++ b/CardGameTests/CardGameTests.swift
@@ -130,6 +130,44 @@ final class CardGameTests: XCTestCase {
         XCTAssertEqual(Set(names ?? []), Set(["Look", "Open"]))
     }
 
+    func testRemoveInteractableConsequence() throws {
+        let vm = GameViewModel()
+        let nodeID = UUID()
+        let action = ActionOption(name: "Trigger",
+                                  actionType: "Skirmish",
+                                  position: .risky,
+                                  effect: .standard,
+                                  requiresTest: false,
+                                  outcomes: [.success: [.removeInteractable(id: "target")]])
+        let target = Interactable(id: "target",
+                                  title: "Target",
+                                  description: "",
+                                  availableActions: [action])
+        let node = MapNode(id: nodeID,
+                           name: "Room",
+                           soundProfile: "",
+                           interactables: [target],
+                           connections: [])
+        vm.gameState.dungeon = DungeonMap(nodes: [nodeID.uuidString: node],
+                                          startingNodeID: nodeID)
+
+        var character = Character(id: UUID(),
+                                  name: "Hero",
+                                  characterClass: "Rogue",
+                                  stress: 0,
+                                  harm: HarmState(),
+                                  actions: ["Skirmish": 1],
+                                  treasures: [],
+                                  modifiers: [])
+        vm.gameState.party = [character]
+        vm.gameState.characterLocations[character.id.uuidString] = nodeID
+
+        _ = vm.performFreeAction(for: action, with: character, interactableID: "target")
+
+        let remaining = vm.gameState.dungeon?.nodes[nodeID.uuidString]?.interactables
+        XCTAssertTrue(remaining?.isEmpty ?? false)
+    }
+
     func testHealHarmConsequence() throws {
         ContentLoader.shared = ContentLoader()
         let vm = GameViewModel()


### PR DESCRIPTION
## Summary
- add `debugConsequences` toggle to `GameViewModel`
- log consequence evaluation and removal steps when debugging is enabled
- fix `removeInteractable` implementation by reassigning the mutated map node
- add unit test ensuring interactable removal works on first attempt

## Testing
- `xcodebuild -scheme CardGame -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -quiet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da84770dc832b895bdea4be522c46